### PR TITLE
Delete the condition that Tencent Cloud detection is liable to cause false positives

### DIFF
--- a/linPEAS/builder/linpeas_parts/3_cloud.sh
+++ b/linPEAS/builder/linpeas_parts/3_cloud.sh
@@ -45,7 +45,7 @@ check_aliyun_ecs () {
 
 check_tencent_cvm () {
   is_tencent_cvm="No"
-  if [ -f "/etc/cloud/cloud.cfg.d/05_logging.cfg" ] || grep -qi Tencent /etc/cloud/cloud.cfg; then
+  if grep -qi Tencent /etc/cloud/cloud.cfg; then
       is_tencent_cvm="Yes"
   fi
 }


### PR DESCRIPTION
Delete the condition that Tencent Cloud detection is liable to cause false positives