### PR TITLE
User folder for cloud creds

### DIFF
--- a/winPEAS/winPEASps1/winPEAS.ps1
+++ b/winPEAS/winPEASps1/winPEAS.ps1
@@ -1282,7 +1282,7 @@ $CCreds = @(".aws\credentials",
   ".azure\azureProfile.json") 
 foreach ($u in $users) {
   $CCreds | ForEach-Object {
-    if (Test-Path "c:\$u\$_") { Write-Host "$_ found!" -ForegroundColor Red }
+    if (Test-Path "c:\Users\$u\$_") { Write-Host "$_ found!" -ForegroundColor Red }
   }
 }
 


### PR DESCRIPTION
I think the path needs to be changed to address the correct location, as only the usernames are in the variable