### PR TITLE
Fixed Select-Objet - winPEAS.ps1

### DIFF
--- a/winPEAS/winPEASps1/winPEAS.ps1
+++ b/winPEAS/winPEASps1/winPEAS.ps1
@@ -68,7 +68,7 @@ Function Start-ACLCheck {
       $Identity += "$env:COMPUTERNAME\$env:USERNAME"
       if ($ACLObject.Owner -like $Identity ) { Write-Host "$Identity has ownership of $Target" -ForegroundColor Red }
       # This should now work for any language. Command runs whoami group, removes the first two line of output, converts from csv to object, but adds "group name" to the first column.
-      whoami.exe /groups /fo csv | select-objet -skip 2 | ConvertFrom-Csv -Header 'group name' | Select-Object -ExpandProperty 'group name' | ForEach-Object { $Identity += $_ }
+      whoami.exe /groups /fo csv | select-object -skip 2 | ConvertFrom-Csv -Header 'group name' | Select-Object -ExpandProperty 'group name' | ForEach-Object { $Identity += $_ }
       $IdentityFound = $false
       foreach ($i in $Identity) {
         $permission = $ACLObject.Access | Where-Object { $_.IdentityReference -like $i }
@@ -1227,7 +1227,7 @@ Write-Host "Will enumerate SMB Shares and Access if any are available"
 Get-SmbShare | Get-SmbShareAccess | ForEach-Object {
   $SMBShareObject = $_
 # see line 70 for explanation of what this does
-  whoami.exe /groups /fo csv | select-objet -skip 2 | ConvertFrom-Csv -Header 'group name' | Select-Object -ExpandProperty 'group name' | ForEach-Object {
+  whoami.exe /groups /fo csv | select-object -skip 2 | ConvertFrom-Csv -Header 'group name' | Select-Object -ExpandProperty 'group name' | ForEach-Object {
     if ($SMBShareObject.AccountName -like $_ -and ($SMBShareObject.AccessRight -like "Full" -or "Change") -and $SMBShareObject.AccessControlType -like "Allow" ) {
       Write-Host -ForegroundColor red "$($SMBShareObject.AccountName) has $($SMBShareObject.AccessRight) to $($SMBShareObject.Name)"
     }


### PR DESCRIPTION
When running winPEAS.ps1, the script doesn't complete properly due to a misspelling of Select-Object.

Typo fixed to ensure script continues to run. 