### PR TITLE
swap ppid and pid user in "PPID belongs to a different user (not root)" test

### DIFF
--- a/linPEAS/builder/linpeas_parts/4_procs_crons_timers_srvcs_sockets/4_Processes_PPID_different_user.sh
+++ b/linPEAS/builder/linpeas_parts/4_procs_crons_timers_srvcs_sockets/4_Processes_PPID_different_user.sh
@@ -28,7 +28,7 @@ if ! [ "$SEARCH_IN_FOLDER" ] && ! [ "$NOUSEPS" ]; then
       continue
     fi
     ppid_user=$(get_user_by_pid "$ppid")
-    if echo "$user" | grep -Eqv "$ppid_user|root$"; then
+    if echo "$ppid_user" | grep -Eqv "$user|root$"; then
       echo "Proc $pid with ppid $ppid is run by user $user but the ppid user is $ppid_user" | sed -${E} "s,$sh_usrs,${SED_LIGHT_CYAN}," | sed "s,$USER,${SED_LIGHT_MAGENTA}," | sed -${E} "s,$nosh_usrs,${SED_BLUE}," | sed "s,root,${SED_RED},"
     fi
   done


### PR DESCRIPTION

Seems like it is reporting processes with ppid user root instead of not root. e.g. I see it reports "proc xyz with ppid 1 is run by user messagebus but the ppid user is root" when run in a linux box