### PR TITLE
Fix echo -n on macOS

### DIFF
--- a/linPEAS/builder/linpeas_parts/linpeas_base/0_variables_base.sh
+++ b/linPEAS/builder/linpeas_parts/linpeas_base/0_variables_base.sh
@@ -188,6 +188,9 @@ if [ $? -ne 0 ] ; then
 	fi
 fi
 
+# on macOS the built-in echo does not support -n, use /bin/echo instead
+if [ "$MACPEAS" ] ; then alias echo=/bin/echo ; fi
+
 print_title(){
   if [ "$DEBUG" ]; then
     END_T1_TIME=$(date +%s 2>/dev/null)


### PR DESCRIPTION
on macOS ( I encountered this on Sequoia 15.2), the built-in command from /bin/sh does not understand the `-n` option, and `echo -n` produces `-n` as output, which leads to false positive in some areas, where the absence of output is tested.

This PR fixes this situation by using /bin/echo when linpeas has detected that it uses macOS.
