### PR TITLE
Set grep to show filename that contains passwords

### DIFF
--- a/linPEAS/builder/linpeas_parts/9_interesting_files/27_Passwords_in_logs.sh
+++ b/linPEAS/builder/linpeas_parts/9_interesting_files/27_Passwords_in_logs.sh
@@ -15,6 +15,6 @@
 
 if ! [ "$SEARCH_IN_FOLDER" ]; then
   print_2title "Searching passwords inside logs (limit 70)"
-  (find /var/log/ /var/logs/ /private/var/log -type f -exec grep -R -i "pwd\|passw" "{}" \;) 2>/dev/null | sed '/^.\{150\}./d' | sort | uniq | grep -v "File does not exist:\|modules-config/config-set-passwords\|config-set-passwords already ran\|script not found or unable to stat:\|\"GET /.*\" 404" | head -n 70 | sed -${E} "s,pwd|passw,${SED_RED},"
+  (find /var/log/ /var/logs/ /private/var/log -type f -exec grep -R -H -i "pwd\|passw" "{}" \;) 2>/dev/null | sed '/^.\{150\}./d' | sort | uniq | grep -v "File does not exist:\|modules-config/config-set-passwords\|config-set-passwords already ran\|script not found or unable to stat:\|\"GET /.*\" 404" | head -n 70 | sed -${E} "s,pwd|passw,${SED_RED},"
   echo ""
 fi


### PR DESCRIPTION
This way one can identify which file contains the relevant information, eg:

```
/var/log/responder/Poisoners-Session.log:2025-02-09 21:12:12,701 - [*] Skipping previously captured cleartext password for donald /var/log/responder/Responder-Session.log:11/02/2025 12:33:11 PM - [HTTP] Basic Password : bambam /var/log/responder/Responder-Session.log:11/02/2025 12:36:12 PM - [HTTP] Basic Password : estrella
```