### PR TITLE
Handle path access denied

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Helpers/MyUtils.cs
+++ b/winPEAS/winPEASexe/winPEAS/Helpers/MyUtils.cs
@@ -184,9 +184,17 @@ namespace winPEAS.Helpers
         //////////////////////
         public static List<string> ListFolder(String path)
         {
-            string root = @Path.GetPathRoot(Environment.SystemDirectory) + path;
-            var dirs = from dir in Directory.EnumerateDirectories(root) select dir;
-            return dirs.ToList();
+            try
+            {
+                string root = @Path.GetPathRoot(Environment.SystemDirectory) + path;
+                var dirs = from dir in Directory.EnumerateDirectories(root) select dir;
+                return dirs.ToList();
+            }
+            catch(Exception ex)
+            {
+                //Path can't be accessed
+                return new List<string>();
+            }
         }
 
         internal static byte[] CombineArrays(byte[] first, byte[] second)


### PR DESCRIPTION
The program crashes when trying to access a path that is not allowed. 
An exampe of this can be found on the latest HackTheBox machine (TheFrizz), where the starting user can't access the path C:\Users