### PR TITLE
Rework PEASS url logic for the metasploit module

### DIFF
--- a/metasploit/README.md
+++ b/metasploit/README.md
@@ -37,9 +37,10 @@ Basic options:
   ----        ---------------                                                           --------  -----------
   PARAMETERS                                                                            no        Parameters to pass to the script
   PASSWORD    um1xipfws17nkw1bi1ma3bh7tzt4mo3e                                          no        Password to encrypt and obfuscate the script (randomly generated). The length must be 32B. If no password is set, only base64 will be used
-                                                                                                  .
-  PEASS_URL   https://raw.githubusercontent.com/peass-ng/PEASS-ng/master/winPEAS/wi  yes       Path to the PEASS script. Accepted: http(s):// URL or absolute local path. Linpeas: https://raw.githubusercontent.com/peass-ng/PEASS-ng
-              nPEASexe/binaries/Obfuscated%20Releases/winPEASany.exe                              /master/linPEAS/linpeas.sh
+
+  WINPEASS    true                                                                      yes       Use PEASS for Windows or PEASS for linux. Default is windows change to false for linux.
+  CUSTOM_URL                                                                            no        Path to the PEASS script. Accepted: http(s):// URL or absolute local path.
+                                            
   SESSION                                                                               yes       The session to run this module on.
   SRVHOST                                                                               no        Set your metasploit instance IP if you want to download the PEASS script from here via http(s) instead of uploading it.
   SRVPORT     443                                                                       no        Port to download the PEASS script from using http(s) (only used if SRVHOST)

--- a/metasploit/peass.rb
+++ b/metasploit/peass.rb
@@ -37,7 +37,8 @@ class MetasploitModule < Msf::Post
     ))
     register_options(
       [
-        OptString.new('PEASS_URL', [true, 'Path to the PEASS script. Accepted: http(s):// URL or absolute local path. Linpeas: https://github.com/peass-ng/PEASS-ng/releases/latest/download/linpeas.sh', "https://github.com/peass-ng/PEASS-ng/releases/latest/download/winPEASany_ofs.exe"]),
+        OptString.new('WINPEASS', [true, 'Which PEASS script to use. Use True for WinPeass and false for LinPEASS', true]),
+        OptString.new('CUSTOM_URL', [false, 'URL to download the PEASS script from (if not using the default one). Accepts http(s) or absolute path. Overrides the WINPEASS variable', '']),
         OptString.new('PASSWORD', [false, 'Password to encrypt and obfuscate the script (randomly generated). The length must be 32B. If no password is set, only base64 will be used.', rand(36**32).to_s(36)]),
         OptString.new('TEMP_DIR', [false, 'Path to upload the obfuscated PEASS script inside the compromised machine. By default "C:\Windows\System32\spool\drivers\color" is used in Windows and "/tmp" in Unix.', '']),
         OptString.new('PARAMETERS', [false, 'Parameters to pass to the script', nil]),
@@ -237,8 +238,14 @@ class MetasploitModule < Msf::Post
   def load_peass
     # Load the PEASS script from a local file or from Internet
     peass_script = ""
-    url_peass = datastore['PEASS_URL']
-    
+    url_peass = ""
+    # If no URL is set, use the default one
+    if datastore['CUSTOM_URL'] != ""
+      url_peass = datastore['CUSTOM_URL']
+    else
+      url_peass = datastore['WINPEASS'] ? "https://github.com/peass-ng/PEASS-ng/releases/latest/download/winPEASany_ofs.exe" : "https://github.com/peass-ng/PEASS-ng/releases/latest/download/linpeas.sh"
+    end
+    # If URL is set, check if it is a valid URL or local file
     if url_peass.include?("http://") || url_peass.include?("https://")
       target = URI.parse url_peass
       raise 'Invalid URL' unless target.scheme =~ /https?/


### PR DESCRIPTION
Most users would use either the winpeas exe or the linpeas sh make the choice more user friendly while retaining the ability to use a custom url or local file