### PR TITLE
Fix url variable reference in linpeasBuilder

### DIFF
--- a/linPEAS/builder/src/linpeasBuilder.py
+++ b/linPEAS/builder/src/linpeasBuilder.py
@@ -97,7 +97,7 @@ class LinpeasBuilder:
         for orig_url in urls:
             tar_gz_bin_name = ""
             if ",,," in orig_url:
-                tar_gz_bin_name = url.split(",,,")[1]
+                tar_gz_bin_name = orig_url.split(",,,")[1]
                 url = orig_url.split(",,,")[0]
             else:
                 url = orig_url


### PR DESCRIPTION
## Summary
- avoid referencing `url` before assignment in `linpeasBuilder.py`

## Testing
- `python -m py_compile linPEAS/builder/src/linpeasBuilder.py`


------
https://chatgpt.com/codex/tasks/task_e_6842131c90748326b9dc32c554f5d670