### PR TITLE
Fix docstring and comment in linpeasBuilder

### DIFF
--- a/linPEAS/builder/src/linpeasBuilder.py
+++ b/linPEAS/builder/src/linpeasBuilder.py
@@ -402,9 +402,9 @@ class LinpeasBuilder:
 
 
     def __replace_mark(self, mark: str, find_calls: list, join_char: str):
-        """Substitude the markup with the actual code"""
-        
-        self.linpeas_sh = self.linpeas_sh.replace(mark, join_char.join(find_calls)) #New line char is't needed
+        """Substitute the markup with the actual code"""
+
+        self.linpeas_sh = self.linpeas_sh.replace(mark, join_char.join(find_calls)) #New line char isn't needed
     
     def write_linpeas(self, path):
         """Write on disk the final linpeas"""


### PR DESCRIPTION
## Summary
- correct wording in `__replace_mark` docstring
- fix typo in comment about newline handling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68421326cfd88326b6fbfb7bea6114f9