### PR TITLE
Fixed multiple bugs in Vulnerable Leaked Handlers

### DIFF
--- a/winPEAS/winPEASexe/winPEAS/Checks/ProcessInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/ProcessInfo.cs
@@ -102,17 +102,15 @@ namespace winPEAS.Checks
                 {
                     vulnHandlers = ProcessesInfo.GetVulnHandlers(progress);
                 }
+                Dictionary<string, string> colors = new Dictionary<string, string>();
+                colors[Checks.CurrentUserName] = Beaprint.ansi_color_bad;
+                colors[HandlesHelper.elevatedProcess] = Beaprint.ansi_color_bad;
 
                 foreach (Dictionary<string, string> handler in vulnHandlers)
                 {
-                    Dictionary<string, string> colors = new Dictionary<string, string>()
-                    {
-                        { Checks.CurrentUserName, Beaprint.ansi_color_bad },
-                        { handler["Reason"], Beaprint.ansi_color_bad },
-                    };
-
-                    Beaprint.DictPrint(vulnHandlers, colors, true);
+                    colors[handler["Reason"]] = Beaprint.ansi_color_bad;
                 }
+                Beaprint.DictPrint(vulnHandlers, colors, true);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
~ HandlesHelper.cs line 175
- Added 0x1FFFFF as detection of PROCESS_ALL_ACCESS like documented in https://learn.microsoft.com/en-us/windows/win32/procthread/process-security-and-access-rights, it also checks out with my testing of the code in https://hacktricks.boitatech.com.br/windows/windows-local-privilege-escalation/leaked-handle-exploitation

~ HandlesHelper.cs lines 15, 458-459, 493-500
- Added helper text to identify possible elevated processes (useful for privesc)
- Handled exception when calling the function GetProcessImageFileName on an elevated process

~ HandlesHelper.cs lines 475-489
- Handled exception when calling the function GetProcessById on a non existent process (it happened during one of my tests)

~ ProcessInfo.cs lines 105-113
- Fixed bug that printed all vulnerable handlers multiple times (Beaprint.DictPrint inside foreach)
- Colorised helper text to identify possible elevated processes (useful for privesc)