### PR TITLE
new-check(linpeas): add high-impact vulnerability detection

### DIFF
--- a/linPEAS/builder/linpeas_parts/7_software_information/Extra_software.sh
+++ b/linPEAS/builder/linpeas_parts/7_software_information/Extra_software.sh
@@ -1,17 +1,21 @@
 # Title: Software Information - Extra sotftare
 # ID: SI_Extra_software
 # Author: Carlos Polop
-# Last Update: 22-08-2023
-# Description: Add all the extra software checks from build_lists/sensitive_files.yaml that doesn't have linpeas disabled
+# Last Update: 17-08-2026
+# Description: Add all extra software checks from build_lists/sensitive_files.yaml and check needrestart interpreter-scanner LPE exposure.
 # License: GNU GPL
-# Version: 1.0
-# Mitre: T1082
-# Functions Used: print_3title, warn_exec
-# Global Variables: $NGINX_KNOWN_MODULES
+# Version: 1.1
+# Mitre: T1082,T1068
+# Functions Used: checkNeedrestartCVE202448990, print_3title, warn_exec
+# Global Variables: $NGINX_KNOWN_MODULES, $SEARCH_IN_FOLDER
 # Initial Functions:
 # Generated Global Variables:
 # Fat linpeas: 0
 # Small linpeas: 1
 
+
+if ! [ "$SEARCH_IN_FOLDER" ]; then
+  checkNeedrestartCVE202448990
+fi
 
 peass{EXTRA_SECTIONS}

--- a/linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh
@@ -1,0 +1,156 @@
+# Title: Functions - checkNeedrestartCVE202448990
+# ID: checkNeedrestartCVE202448990
+# Author: Chack Agent
+# Last Update: 17-08-2026
+# Description: Passively identify needrestart interpreter-scanner local privilege-escalation exposure, including CVE-2024-48990.
+# License: GNU GPL
+# Version: 1.0
+# Mitre: T1068
+# Functions Used: print_3title, print_info
+# Global Variables: $E, $ROOT_FOLDER, $SED_GREEN, $SED_LIGHT_CYAN, $SED_RED_YELLOW, $SED_YELLOW
+# Initial Functions:
+# Generated Global Variables: $nr48990_binary, $nr48990_codename, $nr48990_config, $nr48990_config_file, $nr48990_config_file_value, $nr48990_distro_id, $nr48990_dpkg_fixed, $nr48990_full_version, $nr48990_interpscan, $nr48990_manager, $nr48990_os_release, $nr48990_root, $nr48990_status, $nr48990_ubuntu_codename, $nr48990_upstream_version
+# Fat linpeas: 0
+# Small linpeas: 1
+
+
+nr48990_extract_upstream_version() {
+  printf '%s' "$1" | sed -E 's/^[0-9]+://; s/^[^0-9]*//; s/[^0-9.].*$//'
+}
+
+nr48990_version_lt() {
+  [ -n "$1" ] && [ -n "$2" ] || return 1
+  awk -v nr48990_a="$1" -v nr48990_b="$2" 'BEGIN {
+    nr48990_na = split(nr48990_a, nr48990_av, ".")
+    nr48990_nb = split(nr48990_b, nr48990_bv, ".")
+    nr48990_n = nr48990_na > nr48990_nb ? nr48990_na : nr48990_nb
+    for (nr48990_i = 1; nr48990_i <= nr48990_n; nr48990_i++) {
+      nr48990_ai = nr48990_av[nr48990_i] + 0
+      nr48990_bi = nr48990_bv[nr48990_i] + 0
+      if (nr48990_ai < nr48990_bi) exit 0
+      if (nr48990_ai > nr48990_bi) exit 1
+    }
+    exit 1
+  }'
+}
+
+nr48990_fixed_dpkg_version() {
+  # Vendor backports from Ubuntu CVE-2024-48990 and Debian DSA-5815-1 /
+  # DLA-3957-1; comparing only the upstream 3.8 version would misclassify them.
+  case "$1:$2" in
+    debian:bullseye|raspbian:bullseye) echo "3.5-4+deb11u4" ;;
+    debian:bookworm|raspbian:bookworm) echo "3.6-4+deb12u2" ;;
+    ubuntu:xenial) echo "2.6-1ubuntu0.1~esm1" ;;
+    ubuntu:bionic) echo "3.1-1ubuntu0.1+esm1" ;;
+    ubuntu:focal) echo "3.4-6ubuntu0.1+esm1" ;;
+    ubuntu:jammy) echo "3.5-5ubuntu2.2" ;;
+    ubuntu:noble) echo "3.6-7ubuntu4.3" ;;
+    ubuntu:oracular) echo "3.6-8ubuntu4.2" ;;
+    ubuntu:plucky) echo "3.6-8ubuntu6" ;;
+  esac
+}
+
+nr48990_effective_interpscan() {
+  nr48990_config="1"
+  for nr48990_config_file in "$1"etc/needrestart/needrestart.conf "$1"etc/needrestart/conf.d/*.conf; do
+    [ -r "$nr48990_config_file" ] || continue
+    nr48990_config_file_value="$(awk '
+      /^[[:space:]]*#/ { next }
+      {
+        nr48990_line = $0
+        sub(/[[:space:]]*#.*/, "", nr48990_line)
+        if (nr48990_line ~ /^[[:space:]]*[$]nrconf[[:space:]]*\{[[:space:]]*[\047\042]?interpscan[\047\042]?[[:space:]]*\}[[:space:]]*=[[:space:]]*[01][[:space:]]*;/) {
+          sub(/^.*=[[:space:]]*/, "", nr48990_line)
+          sub(/[[:space:]]*;.*/, "", nr48990_line)
+          print nr48990_line
+        }
+      }
+    ' "$nr48990_config_file" 2>/dev/null | tail -n1)"
+    [ -n "$nr48990_config_file_value" ] && nr48990_config="$nr48990_config_file_value"
+  done
+  printf '%s' "$nr48990_config"
+}
+
+checkNeedrestartCVE202448990() {
+  nr48990_root="${ROOT_FOLDER:-/}"
+  case "$nr48990_root" in
+    */) ;;
+    *) nr48990_root="${nr48990_root}/" ;;
+  esac
+
+  nr48990_binary="$(command -v needrestart 2>/dev/null)"
+  nr48990_full_version=""
+  nr48990_manager=""
+  if command -v dpkg-query >/dev/null 2>&1; then
+    nr48990_full_version="$(dpkg-query --admindir="${nr48990_root}var/lib/dpkg" -W -f='$''{Version}\n' needrestart 2>/dev/null | head -n1)"
+    [ -n "$nr48990_full_version" ] && nr48990_manager="dpkg"
+  fi
+  if [ -z "$nr48990_full_version" ] && command -v rpm >/dev/null 2>&1; then
+    nr48990_full_version="$(rpm --root "$nr48990_root" -q --qf '%{VERSION}-%{RELEASE}\n' needrestart 2>/dev/null | head -n1)"
+    [ -n "$nr48990_full_version" ] && nr48990_manager="rpm"
+  fi
+  [ -n "$nr48990_binary" ] || [ -n "$nr48990_full_version" ] || return
+
+  print_3title "Needrestart interpreter-scanner LPE (CVE-2024-48990)" "T1068"
+  print_info "https://ubuntu.com/security/CVE-2024-48990"
+
+  nr48990_os_release="${nr48990_root}etc/os-release"
+  nr48990_distro_id="$(sed -nE 's/^ID="?([^" ]+)"?$/\1/p' "$nr48990_os_release" 2>/dev/null | head -n1)"
+  nr48990_codename="$(sed -nE 's/^VERSION_CODENAME="?([^" ]+)"?$/\1/p' "$nr48990_os_release" 2>/dev/null | head -n1)"
+  nr48990_ubuntu_codename="$(sed -nE 's/^UBUNTU_CODENAME="?([^" ]+)"?$/\1/p' "$nr48990_os_release" 2>/dev/null | head -n1)"
+  if [ -n "$nr48990_ubuntu_codename" ]; then
+    nr48990_distro_id="ubuntu"
+    nr48990_codename="$nr48990_ubuntu_codename"
+  fi
+
+  nr48990_upstream_version="$(nr48990_extract_upstream_version "$nr48990_full_version")"
+  nr48990_interpscan="$(nr48990_effective_interpscan "$nr48990_root")"
+  nr48990_dpkg_fixed=""
+  nr48990_status="unknown"
+
+  if [ "$nr48990_manager" = "dpkg" ] && command -v dpkg >/dev/null 2>&1; then
+    nr48990_dpkg_fixed="$(nr48990_fixed_dpkg_version "$nr48990_distro_id" "$nr48990_codename")"
+    if [ -n "$nr48990_dpkg_fixed" ]; then
+      if dpkg --compare-versions "$nr48990_full_version" lt "$nr48990_dpkg_fixed"; then
+        nr48990_status="affected"
+      else
+        nr48990_status="fixed"
+      fi
+    fi
+  fi
+  if [ "$nr48990_status" = "unknown" ] && [ -n "$nr48990_upstream_version" ]; then
+    if nr48990_version_lt "$nr48990_upstream_version" "3.8"; then
+      nr48990_status="potential"
+    else
+      nr48990_status="fixed"
+    fi
+  fi
+
+  echo "needrestart package: ${nr48990_full_version:-version unknown}${nr48990_manager:+ ($nr48990_manager)}" | sed -${E} "s,.*,${SED_LIGHT_CYAN},"
+  if [ -n "$nr48990_dpkg_fixed" ]; then
+    echo "Vendor fixed version for ${nr48990_distro_id:-unknown} ${nr48990_codename:-unknown}: $nr48990_dpkg_fixed"
+  fi
+
+  case "$nr48990_status:$nr48990_interpscan" in
+    affected:0|potential:0)
+      echo "Affected needrestart version detected, but the official interpscan=0 mitigation is active; update is still recommended" | sed -${E} "s,.*,${SED_YELLOW},"
+      ;;
+    affected:*)
+      echo "VULNERABLE to CVE-2024-48990: needrestart $nr48990_full_version is below the vendor fixed version and interpreter scanning is enabled" | sed -${E} "s,.*,${SED_RED_YELLOW},"
+      ;;
+    potential:*)
+      echo "Potentially vulnerable to CVE-2024-48990: upstream needrestart $nr48990_upstream_version is before 3.8 and interpreter scanning is enabled; verify distro backports" | sed -${E} "s,.*,${SED_RED_YELLOW},"
+      ;;
+    fixed:*)
+      echo "needrestart $nr48990_full_version is not vulnerable to CVE-2024-48990 according to the known vendor/upstream fixed version" | sed -${E} "s,.*,${SED_GREEN},"
+      ;;
+    unknown:0)
+      echo "needrestart is present; version is unknown, but the interpscan=0 mitigation is active" | sed -${E} "s,.*,${SED_YELLOW},"
+      ;;
+    *)
+      echo "needrestart is present with interpreter scanning enabled, but its version could not be assessed" | sed -${E} "s,.*,${SED_RED_YELLOW},"
+      ;;
+  esac
+  echo "Effective interpreter scanning: $nr48990_interpscan (0=disabled mitigation, 1=enabled/default)"
+  echo ""
+}

--- a/linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh
@@ -9,7 +9,7 @@
 # Functions Used: print_3title, print_info
 # Global Variables: $E, $ROOT_FOLDER, $SED_GREEN, $SED_LIGHT_CYAN, $SED_RED_YELLOW, $SED_YELLOW
 # Initial Functions:
-# Generated Global Variables: $nr48990_binary, $nr48990_codename, $nr48990_config, $nr48990_config_file, $nr48990_config_file_value, $nr48990_distro_id, $nr48990_dpkg_fixed, $nr48990_dpkg_record, $nr48990_full_version, $nr48990_interpscan, $nr48990_manager, $nr48990_os_release, $nr48990_root, $nr48990_rpm_record, $nr48990_status, $nr48990_ubuntu_codename, $nr48990_upstream_version
+# Generated Global Variables: $nr48990_binary, $nr48990_binary_candidate, $nr48990_codename, $nr48990_config, $nr48990_config_file, $nr48990_config_file_value, $nr48990_distro_id, $nr48990_dpkg_fixed, $nr48990_dpkg_record, $nr48990_full_version, $nr48990_interpscan, $nr48990_manager, $nr48990_os_release, $nr48990_root, $nr48990_rpm_record, $nr48990_status, $nr48990_ubuntu_codename, $nr48990_upstream_version
 # Fat linpeas: 0
 # Small linpeas: 1
 
@@ -78,7 +78,17 @@ checkNeedrestartCVE202448990() {
     *) nr48990_root="${nr48990_root}/" ;;
   esac
 
-  nr48990_binary="$(command -v needrestart 2>/dev/null)"
+  nr48990_binary=""
+  if [ "$nr48990_root" = "/" ]; then
+    nr48990_binary="$(command -v needrestart 2>/dev/null)"
+  else
+    for nr48990_binary_candidate in usr/sbin/needrestart usr/bin/needrestart sbin/needrestart bin/needrestart; do
+      if [ -f "${nr48990_root}${nr48990_binary_candidate}" ]; then
+        nr48990_binary="${nr48990_root}${nr48990_binary_candidate}"
+        break
+      fi
+    done
+  fi
   nr48990_full_version=""
   nr48990_manager=""
   if command -v dpkg-query >/dev/null 2>&1; then

--- a/linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh
@@ -40,6 +40,7 @@ nr48990_fixed_dpkg_version() {
   case "$1:$2" in
     debian:bullseye|raspbian:bullseye) echo "3.5-4+deb11u4" ;;
     debian:bookworm|raspbian:bookworm) echo "3.6-4+deb12u2" ;;
+    debian:trixie|debian:forky|debian:sid) echo "3.7-3.1" ;;
     ubuntu:xenial) echo "2.6-1ubuntu0.1~esm1" ;;
     ubuntu:bionic) echo "3.1-1ubuntu0.1+esm1" ;;
     ubuntu:focal) echo "3.4-6ubuntu0.1+esm1" ;;

--- a/linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh
@@ -1,15 +1,15 @@
 # Title: Functions - checkNeedrestartCVE202448990
 # ID: checkNeedrestartCVE202448990
 # Author: Chack Agent
-# Last Update: 17-08-2026
+# Last Update: 24-08-2026
 # Description: Passively identify needrestart interpreter-scanner local privilege-escalation exposure, including CVE-2024-48990.
 # License: GNU GPL
-# Version: 1.0
+# Version: 1.1
 # Mitre: T1068
 # Functions Used: print_3title, print_info
 # Global Variables: $E, $ROOT_FOLDER, $SED_GREEN, $SED_LIGHT_CYAN, $SED_RED_YELLOW, $SED_YELLOW
 # Initial Functions:
-# Generated Global Variables: $nr48990_binary, $nr48990_codename, $nr48990_config, $nr48990_config_file, $nr48990_config_file_value, $nr48990_distro_id, $nr48990_dpkg_fixed, $nr48990_full_version, $nr48990_interpscan, $nr48990_manager, $nr48990_os_release, $nr48990_root, $nr48990_status, $nr48990_ubuntu_codename, $nr48990_upstream_version
+# Generated Global Variables: $nr48990_binary, $nr48990_codename, $nr48990_config, $nr48990_config_file, $nr48990_config_file_value, $nr48990_distro_id, $nr48990_dpkg_fixed, $nr48990_dpkg_record, $nr48990_full_version, $nr48990_interpscan, $nr48990_manager, $nr48990_os_release, $nr48990_root, $nr48990_status, $nr48990_ubuntu_codename, $nr48990_upstream_version
 # Fat linpeas: 0
 # Small linpeas: 1
 
@@ -82,14 +82,19 @@ checkNeedrestartCVE202448990() {
   nr48990_full_version=""
   nr48990_manager=""
   if command -v dpkg-query >/dev/null 2>&1; then
-    nr48990_full_version="$(dpkg-query --admindir="${nr48990_root}var/lib/dpkg" -W -f='$''{Version}\n' needrestart 2>/dev/null | head -n1)"
-    [ -n "$nr48990_full_version" ] && nr48990_manager="dpkg"
+    nr48990_dpkg_record="$(dpkg-query --admindir="${nr48990_root}var/lib/dpkg" -W -f='$''{Status}|$''{Version}\n' needrestart 2>/dev/null | head -n1)"
+    case "$nr48990_dpkg_record" in
+      "install ok installed|"*)
+        nr48990_full_version="${nr48990_dpkg_record#*|}"
+        [ -n "$nr48990_full_version" ] && nr48990_manager="dpkg"
+        ;;
+    esac
   fi
   if [ -z "$nr48990_full_version" ] && command -v rpm >/dev/null 2>&1; then
     nr48990_full_version="$(rpm --root "$nr48990_root" -q --qf '%{VERSION}-%{RELEASE}\n' needrestart 2>/dev/null | head -n1)"
     [ -n "$nr48990_full_version" ] && nr48990_manager="rpm"
   fi
-  [ -n "$nr48990_binary" ] || [ -n "$nr48990_full_version" ] || return
+  [ -n "$nr48990_binary" ] || [ -n "$nr48990_full_version" ] || return 0
 
   print_3title "Needrestart interpreter-scanner LPE (CVE-2024-48990)" "T1068"
   print_info "https://ubuntu.com/security/CVE-2024-48990"

--- a/linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh
@@ -9,7 +9,7 @@
 # Functions Used: print_3title, print_info
 # Global Variables: $E, $ROOT_FOLDER, $SED_GREEN, $SED_LIGHT_CYAN, $SED_RED_YELLOW, $SED_YELLOW
 # Initial Functions:
-# Generated Global Variables: $nr48990_binary, $nr48990_codename, $nr48990_config, $nr48990_config_file, $nr48990_config_file_value, $nr48990_distro_id, $nr48990_dpkg_fixed, $nr48990_dpkg_record, $nr48990_full_version, $nr48990_interpscan, $nr48990_manager, $nr48990_os_release, $nr48990_root, $nr48990_status, $nr48990_ubuntu_codename, $nr48990_upstream_version
+# Generated Global Variables: $nr48990_binary, $nr48990_codename, $nr48990_config, $nr48990_config_file, $nr48990_config_file_value, $nr48990_distro_id, $nr48990_dpkg_fixed, $nr48990_dpkg_record, $nr48990_full_version, $nr48990_interpscan, $nr48990_manager, $nr48990_os_release, $nr48990_root, $nr48990_rpm_record, $nr48990_status, $nr48990_ubuntu_codename, $nr48990_upstream_version
 # Fat linpeas: 0
 # Small linpeas: 1
 
@@ -91,8 +91,10 @@ checkNeedrestartCVE202448990() {
     esac
   fi
   if [ -z "$nr48990_full_version" ] && command -v rpm >/dev/null 2>&1; then
-    nr48990_full_version="$(rpm --root "$nr48990_root" -q --qf '%{VERSION}-%{RELEASE}\n' needrestart 2>/dev/null | head -n1)"
-    [ -n "$nr48990_full_version" ] && nr48990_manager="rpm"
+    if nr48990_rpm_record="$(rpm --root "$nr48990_root" -q --qf '%{VERSION}-%{RELEASE}\n' needrestart 2>/dev/null)"; then
+      nr48990_full_version="$(printf '%s\n' "$nr48990_rpm_record" | head -n1)"
+      [ -n "$nr48990_full_version" ] && nr48990_manager="rpm"
+    fi
   fi
   [ -n "$nr48990_binary" ] || [ -n "$nr48990_full_version" ] || return 0
 

--- a/linPEAS/tests/test_needrestart.py
+++ b/linPEAS/tests/test_needrestart.py
@@ -58,6 +58,14 @@ class NeedrestartCVE202448990Tests(unittest.TestCase):
             encoding="utf-8",
         )
         dpkg.chmod(0o755)
+        rpm = bindir / "rpm"
+        rpm.write_text(
+            '#!/bin/sh\n'
+            'echo "package needrestart is not installed"\n'
+            'exit 1\n',
+            encoding="utf-8",
+        )
+        rpm.chmod(0o755)
 
         env = os.environ.copy()
         env.update(

--- a/linPEAS/tests/test_needrestart.py
+++ b/linPEAS/tests/test_needrestart.py
@@ -1,0 +1,134 @@
+import os
+import shlex
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class NeedrestartCVE202448990Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.repo_root = Path(__file__).resolve().parents[2]
+        cls.function_file = (
+            cls.repo_root
+            / "linPEAS"
+            / "builder"
+            / "linpeas_parts"
+            / "functions"
+            / "checkNeedrestartCVE202448990.sh"
+        )
+
+    def _make_root(self, base, main_value=None, snippet_value=None):
+        root = base / "root"
+        (root / "etc" / "needrestart" / "conf.d").mkdir(parents=True)
+        (root / "var" / "lib" / "dpkg").mkdir(parents=True)
+        (root / "etc" / "os-release").write_text(
+            'ID=ubuntu\nVERSION_CODENAME=noble\nVERSION_ID="24.04"\n',
+            encoding="utf-8",
+        )
+        if main_value is not None:
+            (root / "etc" / "needrestart" / "needrestart.conf").write_text(
+                f"$nrconf{{interpscan}} = {main_value};\n", encoding="utf-8"
+            )
+        if snippet_value is not None:
+            (root / "etc" / "needrestart" / "conf.d" / "99-security.conf").write_text(
+                f"$nrconf{{'interpscan'}} = {snippet_value};\n", encoding="utf-8"
+            )
+        return root
+
+    def _run_check(self, root, package_version):
+        bindir = root.parent / "bin"
+        bindir.mkdir()
+        dpkg_query = bindir / "dpkg-query"
+        dpkg_query.write_text(
+            '#!/bin/sh\nprintf "%s\\n" "$FAKE_NEEDRESTART_VERSION"\n',
+            encoding="utf-8",
+        )
+        dpkg_query.chmod(0o755)
+        dpkg = bindir / "dpkg"
+        dpkg.write_text('#!/bin/sh\nexec /usr/bin/dpkg "$@"\n', encoding="utf-8")
+        dpkg.chmod(0o755)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "FAKE_NEEDRESTART_VERSION": package_version,
+                "PATH": f"{bindir}:{env['PATH']}",
+            }
+        )
+        body = "\n".join(
+            [
+                f"ROOT_FOLDER={shlex.quote(str(root))}",
+                "E=E",
+                "SED_GREEN='&'",
+                "SED_LIGHT_CYAN='&'",
+                "SED_RED_YELLOW='&'",
+                "SED_YELLOW='&'",
+                'print_3title() { echo "TITLE: $1"; }',
+                "print_info() { :; }",
+                f". {shlex.quote(str(self.function_file))}",
+                "checkNeedrestartCVE202448990",
+            ]
+        )
+        return subprocess.run(
+            ["sh", "-c", body],
+            cwd=str(self.repo_root),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_vulnerable_ubuntu_package_with_default_scanner_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir))
+            result = self._run_check(root, "3.6-7ubuntu4.2")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("TITLE: Needrestart interpreter-scanner LPE", result.stdout)
+        self.assertIn("VULNERABLE to CVE-2024-48990", result.stdout)
+        self.assertIn("Effective interpreter scanning: 1", result.stdout)
+
+    def test_vendor_fixed_ubuntu_package_is_not_flagged(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir))
+            result = self._run_check(root, "3.6-7ubuntu4.3")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("is not vulnerable to CVE-2024-48990", result.stdout)
+        self.assertNotIn("VULNERABLE to CVE-2024-48990", result.stdout)
+
+    def test_conf_d_mitigation_overrides_main_configuration(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir), main_value=1, snippet_value=0)
+            result = self._run_check(root, "3.6-7ubuntu4.2")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("interpscan=0 mitigation is active", result.stdout)
+        self.assertIn("Effective interpreter scanning: 0", result.stdout)
+        self.assertNotIn("VULNERABLE to CVE-2024-48990", result.stdout)
+
+    def test_upstream_version_comparison_handles_double_digit_components(self):
+        body = "\n".join(
+            [
+                f". {shlex.quote(str(self.function_file))}",
+                "nr48990_version_lt 3.7 3.8 && echo old=yes",
+                "nr48990_version_lt 3.10 3.8 || echo new=yes",
+            ]
+        )
+        result = subprocess.run(
+            ["sh", "-c", body],
+            cwd=str(self.repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("old=yes", result.stdout)
+        self.assertIn("new=yes", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/linPEAS/tests/test_needrestart.py
+++ b/linPEAS/tests/test_needrestart.py
@@ -37,23 +37,36 @@ class NeedrestartCVE202448990Tests(unittest.TestCase):
             )
         return root
 
-    def _run_check(self, root, package_version):
+    def _run_check(self, root, package_version, package_status="install ok installed"):
         bindir = root.parent / "bin"
         bindir.mkdir()
         dpkg_query = bindir / "dpkg-query"
         dpkg_query.write_text(
-            '#!/bin/sh\nprintf "%s\\n" "$FAKE_NEEDRESTART_VERSION"\n',
+            '#!/bin/sh\nprintf "%s|%s\\n" "$FAKE_NEEDRESTART_STATUS" '
+            '"$FAKE_NEEDRESTART_VERSION"\n',
             encoding="utf-8",
         )
         dpkg_query.chmod(0o755)
         dpkg = bindir / "dpkg"
-        dpkg.write_text('#!/bin/sh\nexec /usr/bin/dpkg "$@"\n', encoding="utf-8")
+        dpkg.write_text(
+            '#!/bin/sh\n'
+            'if [ "$1" = "--compare-versions" ]; then\n'
+            '  [ "$FAKE_DPKG_VERSION_IS_OLDER" = "1" ]\n'
+            '  exit\n'
+            'fi\n'
+            'exit 1\n',
+            encoding="utf-8",
+        )
         dpkg.chmod(0o755)
 
         env = os.environ.copy()
         env.update(
             {
+                "FAKE_NEEDRESTART_STATUS": package_status,
                 "FAKE_NEEDRESTART_VERSION": package_version,
+                "FAKE_DPKG_VERSION_IS_OLDER": (
+                    "1" if package_version == "3.6-7ubuntu4.2" else "0"
+                ),
                 "PATH": f"{bindir}:{env['PATH']}",
             }
         )
@@ -97,6 +110,19 @@ class NeedrestartCVE202448990Tests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("is not vulnerable to CVE-2024-48990", result.stdout)
+        self.assertNotIn("VULNERABLE to CVE-2024-48990", result.stdout)
+
+    def test_removed_package_with_remaining_config_is_ignored(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir))
+            result = self._run_check(
+                root,
+                "3.6-7ubuntu4.2",
+                package_status="deinstall ok config-files",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("Needrestart interpreter-scanner LPE", result.stdout)
         self.assertNotIn("VULNERABLE to CVE-2024-48990", result.stdout)
 
     def test_conf_d_mitigation_overrides_main_configuration(self):

--- a/linPEAS/tests/test_needrestart.py
+++ b/linPEAS/tests/test_needrestart.py
@@ -120,6 +120,18 @@ class NeedrestartCVE202448990Tests(unittest.TestCase):
         self.assertIn("is not vulnerable to CVE-2024-48990", result.stdout)
         self.assertNotIn("VULNERABLE to CVE-2024-48990", result.stdout)
 
+    def test_vendor_fixed_debian_backport_is_not_flagged(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir))
+            (root / "etc" / "os-release").write_text(
+                "ID=debian\nVERSION_CODENAME=trixie\n", encoding="utf-8"
+            )
+            result = self._run_check(root, "3.7-3.1")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("is not vulnerable to CVE-2024-48990", result.stdout)
+        self.assertNotIn("Potentially vulnerable to CVE-2024-48990", result.stdout)
+
     def test_removed_package_with_remaining_config_is_ignored(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = self._make_root(Path(tmpdir))


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->

<!-- daily-stats-summary: Proposed one high-impact linpeas vulnerability check. -->

Automated proposal for one new, high-impact `linpeas` vulnerability-detection check.

Agent research and validation summary:
PEASS linpeas new-check agent completed successfully with 31 steps. Agent Comment: ## Implemented check

**Needrestart interpreter-scanner LPE — CVE-2024-48990**

This is exceptionally relevant because it enables low-complexity local escalation to root, and `needrestart` has been installed by default on Ubuntu Server since 21.04. The vulnerability affects upstream versions before 3.8, with distribution-specific backported fixes. [Ubuntu CVE advisory](https://ubuntu.com/security/CVE-2024-48990), [Canonical analysis](https://ubuntu.com/blog/needrestart-local-privilege-escalation), [Debian advisory](https://lists.debian.org/debian-security-announce/2024/msg00229.html), [upstream fix](https://github.com/liske/needrestart/commit/fcc9a4401392231bef4ef5ed026a0d7a275149ab).

### Detection behavior

The passive check:

- Detects installed `needrestart` packages through `dpkg-query` or RPM metadata without executing the program.
- Compares complete package versions against Ubuntu and Debian security-fixed versions, correctly handling vendor backports.
- Uses upstream version 3.8 as a conservative fallback for unknown distributions.
- Reads `needrestart.conf` and ordered `conf.d/*.conf` snippets to determine whether the official `interpscan=0` mitigation is effective.
- Clearly distinguishes vulnerable, potentially vulnerable, mitigated, fixed, and unknown-version states.

### Files changed

- `linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh`
- `linPEAS/builder/linpeas_parts/7_software_information/Extra_software.sh`
- `linPEAS/tests/test_needrestart.py`

### Validation

- POSIX shell syntax checks passed for both modified shell files.
- Focused needrestart regression tests: **4 passed**.
- `python3 -m unittest linPEAS.tests.test_modules_metadata`: **8 passed**.
- Full linPEAS test discovery: **36 passed**.
- Builder completed successfully to `/tmp/linpeas_new_check.sh`.
- Generated script passed `sh -n` and contains the new helper and invocation.
- Final diff and whitespace checks passed; no generated repository files were modified.

Generated by the PEASS New Vulnerability Checks workflow. This PR must pass PEASS PR-tests and normal Chack-Agent review.
