### PR TITLE
new-check(winpeas): add high-impact vulnerability detection

### DIFF
--- a/winPEAS/winPEASexe/Tests/PrivilegedScheduledTaskTests.cs
+++ b/winPEAS/winPEASexe/Tests/PrivilegedScheduledTaskTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Security.AccessControl;
+using winPEAS.Info.ApplicationInfo;
+
+namespace winPEAS.Tests
+{
+    [TestClass]
+    public class PrivilegedScheduledTaskTests
+    {
+        private static readonly HashSet<string> StandardUserSids = new HashSet<string>
+        {
+            "S-1-5-32-545",
+        };
+
+        [TestMethod]
+        public void RecognizesOnlyLocalSystemPrincipalForms()
+        {
+            Assert.IsTrue(PrivilegedScheduledTasks.IsLocalSystemPrincipal("S-1-5-18"));
+            Assert.IsTrue(PrivilegedScheduledTasks.IsLocalSystemPrincipal("SYSTEM"));
+            Assert.IsTrue(PrivilegedScheduledTasks.IsLocalSystemPrincipal(@"NT AUTHORITY\SYSTEM"));
+            Assert.IsTrue(PrivilegedScheduledTasks.IsLocalSystemPrincipal("LocalSystem"));
+            Assert.IsFalse(PrivilegedScheduledTasks.IsLocalSystemPrincipal(@"BUILTIN\Administrators"));
+            Assert.IsFalse(PrivilegedScheduledTasks.IsLocalSystemPrincipal("S-1-5-19"));
+        }
+
+        [TestMethod]
+        public void ExtractsExecutableAndScriptPathsFromArguments()
+        {
+            List<string> paths = PrivilegedScheduledTasks.ExtractReferencedFilePaths(
+                @"-File ""C:\Program Files\Ops\rotate.ps1"" /then C:\Jobs\cleanup.cmd C:\Notes\readme.txt",
+                null);
+
+            CollectionAssert.Contains(paths, @"C:\Program Files\Ops\rotate.ps1");
+            CollectionAssert.Contains(paths, @"C:\Jobs\cleanup.cmd");
+            CollectionAssert.DoesNotContain(paths, @"C:\Notes\readme.txt");
+        }
+
+        [TestMethod]
+        public void HonorsWriteDenyBeforeAllow()
+        {
+            var allowed = new RawSecurityDescriptor("O:BAG:SYD:(A;;0x2;;;BU)");
+            var denied = new RawSecurityDescriptor("O:BAG:SYD:(D;;0x2;;;BU)(A;;0x2;;;BU)");
+
+            Assert.AreEqual(
+                "S-1-5-32-545",
+                PrivilegedScheduledTasks.FindWriteTrustee(allowed, StandardUserSids, 0x2));
+            Assert.IsNull(PrivilegedScheduledTasks.FindWriteTrustee(denied, StandardUserSids, 0x2));
+        }
+
+        [TestMethod]
+        public void RequiresCreateAndDeleteChildForExistingFileReplacement()
+        {
+            var createOnly = new RawSecurityDescriptor("O:BAG:SYD:(A;;0x2;;;BU)");
+            var replace = new RawSecurityDescriptor("O:BAG:SYD:(A;;0x42;;;BU)");
+
+            Assert.IsNull(PrivilegedScheduledTasks.FindDirectoryReplacementTrustee(createOnly, StandardUserSids));
+            Assert.AreEqual(
+                "S-1-5-32-545",
+                PrivilegedScheduledTasks.FindDirectoryReplacementTrustee(replace, StandardUserSids));
+        }
+    }
+}

--- a/winPEAS/winPEASexe/Tests/PrivilegedScheduledTaskTests.cs
+++ b/winPEAS/winPEASexe/Tests/PrivilegedScheduledTaskTests.cs
@@ -121,5 +121,20 @@ namespace winPEAS.Tests
                 "S-1-5-32-545",
                 PrivilegedScheduledTasks.FindDirectoryReplacementTrustee(replace, StandardUserSids));
         }
+
+        [TestMethod]
+        public void CombinesReplacementRightsAcrossTokenGroups()
+        {
+            var standardTokenSids = new HashSet<string>
+            {
+                "S-1-1-0",
+                "S-1-5-32-545",
+            };
+            var replace = new RawSecurityDescriptor("O:BAG:SYD:(A;;0x2;;;WD)(A;;0x40;;;BU)");
+
+            Assert.AreEqual(
+                "S-1-1-0 and S-1-5-32-545",
+                PrivilegedScheduledTasks.FindDirectoryReplacementTrustee(replace, standardTokenSids));
+        }
     }
 }

--- a/winPEAS/winPEASexe/Tests/PrivilegedScheduledTaskTests.cs
+++ b/winPEAS/winPEASexe/Tests/PrivilegedScheduledTaskTests.cs
@@ -25,15 +25,77 @@ namespace winPEAS.Tests
         }
 
         [TestMethod]
-        public void ExtractsExecutableAndScriptPathsFromArguments()
+        public void ExtractsPowerShellFileArgument()
         {
             List<string> paths = PrivilegedScheduledTasks.ExtractReferencedFilePaths(
-                @"-File ""C:\Program Files\Ops\rotate.ps1"" /then C:\Jobs\cleanup.cmd C:\Notes\readme.txt",
+                @"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+                @"-NoProfile -File ""C:\Program Files\Ops\rotate.ps1""",
                 null);
 
             CollectionAssert.Contains(paths, @"C:\Program Files\Ops\rotate.ps1");
-            CollectionAssert.Contains(paths, @"C:\Jobs\cleanup.cmd");
-            CollectionAssert.DoesNotContain(paths, @"C:\Notes\readme.txt");
+        }
+
+        [TestMethod]
+        public void IgnoresDataAndOutputArgumentsForOrdinaryExecutables()
+        {
+            List<string> paths = PrivilegedScheduledTasks.ExtractReferencedFilePaths(
+                @"C:\Tools\processor.exe",
+                @"/copy C:\Data\payload.dll --output C:\Reports\result.jar",
+                null);
+
+            Assert.AreEqual(0, paths.Count);
+        }
+
+        [TestMethod]
+        public void IgnoresInlineInterpreterCodeThatLooksLikeAPath()
+        {
+            List<string> paths = PrivilegedScheduledTasks.ExtractReferencedFilePaths(
+                @"C:\Python311\python.exe",
+                @"-c ""C:\Reports\not-a-script.py""",
+                null);
+
+            Assert.AreEqual(0, paths.Count);
+        }
+
+        [TestMethod]
+        public void ExtractsCmdAndJavaExecutionTargetsOnlyFromKnownSwitches()
+        {
+            List<string> cmdPaths = PrivilegedScheduledTasks.ExtractReferencedFilePaths(
+                @"C:\Windows\System32\cmd.exe",
+                @"/c call C:\Jobs\cleanup.cmd --output C:\Reports\result.jar",
+                null);
+            List<string> javaPaths = PrivilegedScheduledTasks.ExtractReferencedFilePaths(
+                @"C:\Program Files\Java\bin\java.exe",
+                @"--class-path C:\Libraries\support.jar -jar C:\Apps\worker.jar",
+                null);
+
+            CollectionAssert.AreEqual(new List<string> { @"C:\Jobs\cleanup.cmd" }, cmdPaths);
+            CollectionAssert.AreEqual(new List<string> { @"C:\Apps\worker.jar" }, javaPaths);
+        }
+
+        [TestMethod]
+        public void RejectsNetworkDriveTypes()
+        {
+            Assert.IsTrue(PrivilegedScheduledTasks.IsAllowedDriveType(System.IO.DriveType.Fixed));
+            Assert.IsFalse(PrivilegedScheduledTasks.IsAllowedDriveType(System.IO.DriveType.Network));
+            Assert.IsFalse(PrivilegedScheduledTasks.IsAllowedDriveType(System.IO.DriveType.Unknown));
+        }
+
+        [TestMethod]
+        public void EnforcesGlobalTargetAndTimeBudgets()
+        {
+            var targetLimited = new PrivilegedScheduledTaskReport
+            {
+                TargetsInspected = PrivilegedScheduledTasks.MaxTargets,
+            };
+            var timeLimited = new PrivilegedScheduledTaskReport();
+
+            Assert.IsTrue(PrivilegedScheduledTasks.ApplySafetyLimits(targetLimited, 0));
+            Assert.IsTrue(targetLimited.TargetLimitReached);
+            Assert.IsTrue(PrivilegedScheduledTasks.ApplySafetyLimits(
+                timeLimited,
+                PrivilegedScheduledTasks.MaxInspectionMilliseconds));
+            Assert.IsTrue(timeLimited.TimeLimitReached);
         }
 
         [TestMethod]

--- a/winPEAS/winPEASexe/Tests/winPEAS.Tests.csproj
+++ b/winPEAS/winPEASexe/Tests/winPEAS.Tests.csproj
@@ -98,6 +98,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArgumentParsingTests.cs" />
+    <Compile Include="PrivilegedScheduledTaskTests.cs" />
     <Compile Include="RegistryHiveExposureTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SmokeTests.cs" />

--- a/winPEAS/winPEASexe/winPEAS/Checks/ApplicationsInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/ApplicationsInfo.cs
@@ -21,6 +21,7 @@ namespace winPEAS.Checks
                 PrintOnlinePackageVulnerabilities,
                 PrintAutoRuns,
                 PrintScheduled,
+                PrintWritableSystemTaskTargets,
                 PrintDeviceDrivers,
             }.ForEach(action => CheckRunner.Run(action, isDebug));
         }
@@ -271,6 +272,49 @@ namespace winPEAS.Checks
                     };
                     Beaprint.AnsiPrint(string.Format(formString, sapp["Author"], sapp["Name"], sapp["Action"], string.Join(", ", fileRights), string.Join(", ", dirRights), sapp["Trigger"], sapp["Description"]), colorsS);
                     Beaprint.PrintLineSeparator();
+                }
+            }
+            catch (Exception ex)
+            {
+                Beaprint.PrintException(ex.Message);
+            }
+        }
+
+        void PrintWritableSystemTaskTargets()
+        {
+            try
+            {
+                Beaprint.MainPrint("Writable execution targets in enabled SYSTEM scheduled tasks", "T1053.005");
+                Beaprint.LinkPrint("https://attack.mitre.org/techniques/T1053/005/", "A writable executable or script launched by a SYSTEM task can provide privilege escalation when the task next runs.");
+
+                PrivilegedScheduledTaskReport report = PrivilegedScheduledTasks.GetReport();
+                if (report.Findings.Count == 0)
+                {
+                    Beaprint.GoodPrint($"    No writable targets found within {report.TasksInspected} inspected task(s).");
+                }
+
+                foreach (PrivilegedScheduledTaskFinding finding in report.Findings)
+                {
+                    Beaprint.BadPrint($"    Task: {finding.TaskPath} ({finding.Principal})");
+                    Beaprint.NoColorPrint($"    Action: {finding.Executable}");
+                    Beaprint.BadPrint($"    Writable target: {finding.TargetPath}");
+                    Beaprint.BadPrint($"    Access: {finding.AccessReason}");
+                    Beaprint.PrintLineSeparator();
+                }
+
+                if (report.TaskLimitReached)
+                {
+                    Beaprint.NoColorPrint($"    Task inspection stopped at the safety limit of {PrivilegedScheduledTasks.MaxTasks} tasks.");
+                }
+
+                if (report.FolderLimitReached)
+                {
+                    Beaprint.NoColorPrint($"    Folder inspection stopped at the safety limit of {PrivilegedScheduledTasks.MaxFolders} folders.");
+                }
+
+                if (report.FindingLimitReached)
+                {
+                    Beaprint.NoColorPrint($"    Findings were capped at {PrivilegedScheduledTasks.MaxFindings}.");
                 }
             }
             catch (Exception ex)

--- a/winPEAS/winPEASexe/winPEAS/Checks/ApplicationsInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/ApplicationsInfo.cs
@@ -316,6 +316,16 @@ namespace winPEAS.Checks
                 {
                     Beaprint.NoColorPrint($"    Findings were capped at {PrivilegedScheduledTasks.MaxFindings}.");
                 }
+
+                if (report.TargetLimitReached)
+                {
+                    Beaprint.NoColorPrint($"    Filesystem probes stopped at the safety limit of {PrivilegedScheduledTasks.MaxTargets} targets.");
+                }
+
+                if (report.TimeLimitReached)
+                {
+                    Beaprint.NoColorPrint($"    Inspection stopped at the safety limit of {PrivilegedScheduledTasks.MaxInspectionMilliseconds / 1000} seconds.");
+                }
             }
             catch (Exception ex)
             {

--- a/winPEAS/winPEASexe/winPEAS/Info/ApplicationInfo/PrivilegedScheduledTasks.cs
+++ b/winPEAS/winPEASexe/winPEAS/Info/ApplicationInfo/PrivilegedScheduledTasks.cs
@@ -633,17 +633,16 @@ namespace winPEAS.Info.ApplicationInfo
                 return controlTrustee;
             }
 
-            foreach (string sid in unprivilegedSids)
+            string createTrustee = FindWriteTrustee(descriptor, unprivilegedSids, FileWriteData);
+            string deleteTrustee = FindWriteTrustee(descriptor, unprivilegedSids, FileDeleteChild);
+            if (string.IsNullOrEmpty(createTrustee) || string.IsNullOrEmpty(deleteTrustee))
             {
-                var singleSid = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { sid };
-                if (!string.IsNullOrEmpty(FindWriteTrustee(descriptor, singleSid, FileWriteData)) &&
-                    !string.IsNullOrEmpty(FindWriteTrustee(descriptor, singleSid, FileDeleteChild)))
-                {
-                    return sid;
-                }
+                return null;
             }
 
-            return null;
+            return createTrustee.Equals(deleteTrustee, StringComparison.OrdinalIgnoreCase)
+                ? createTrustee
+                : createTrustee + " and " + deleteTrustee;
         }
 
         internal static string FindWriteTrustee(

--- a/winPEAS/winPEASexe/winPEAS/Info/ApplicationInfo/PrivilegedScheduledTasks.cs
+++ b/winPEAS/winPEASexe/winPEAS/Info/ApplicationInfo/PrivilegedScheduledTasks.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Security.AccessControl;
 using System.Security.Principal;
@@ -27,7 +28,11 @@ namespace winPEAS.Info.ApplicationInfo
         public int TasksInspected { get; set; }
         public bool FolderLimitReached { get; set; }
         public bool TaskLimitReached { get; set; }
+        public bool TargetLimitReached { get; set; }
+        public bool TimeLimitReached { get; set; }
         public bool FindingLimitReached { get; set; }
+        public int TargetsInspected { get; set; }
+        internal Stopwatch InspectionTimer { get; } = Stopwatch.StartNew();
     }
 
     internal static class PrivilegedScheduledTasks
@@ -35,6 +40,8 @@ namespace winPEAS.Info.ApplicationInfo
         internal const int MaxTasks = 2048;
         internal const int MaxFindings = 64;
         internal const int MaxFolders = 1024;
+        internal const int MaxTargets = 2048;
+        internal const int MaxInspectionMilliseconds = 15000;
         private const int MaxFolderDepth = 32;
         private const int MaxTargetsPerAction = 16;
         private const int MaxArgumentLength = 8192;
@@ -47,20 +54,39 @@ namespace winPEAS.Info.ApplicationInfo
         private const uint GenericWrite = 0x40000000;
         private const uint GenericAll = 0x10000000;
 
-        private static readonly Regex AbsoluteFileReference = new Regex(
-            @"(?i)(?:[a-z]:\\|\\\\)[^""'\r\n]*?\.(?:exe|com|dll|ps1|psm1|bat|cmd|vbs|vbe|js|jse|wsf|wsh|hta|py|pl|rb|jar)(?=$|[\s,""';)&|])",
-            RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
         private static readonly HashSet<string> ReplaceableScriptExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             ".ps1", ".psm1", ".bat", ".cmd", ".vbs", ".vbe", ".js", ".jse",
             ".wsf", ".wsh", ".hta", ".py", ".pl", ".rb",
         };
 
-        private static readonly HashSet<string> ExecutableOrScriptExtensions = new HashSet<string>(ReplaceableScriptExtensions, StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> HtaExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            ".exe", ".com", ".dll", ".jar",
+            ".hta",
         };
+
+        private static readonly HashSet<string> PowerShellScriptExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".ps1", ".psm1",
+        };
+
+        private static readonly HashSet<string> CmdTargetExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".exe", ".com", ".bat", ".cmd",
+        };
+
+        private static readonly HashSet<string> WindowsScriptHostExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".vbs", ".vbe", ".js", ".jse", ".wsf", ".wsh",
+        };
+
+        private static readonly HashSet<string> PythonScriptExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".py" };
+        private static readonly HashSet<string> PerlScriptExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".pl" };
+        private static readonly HashSet<string> RubyScriptExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".rb" };
+        private static readonly HashSet<string> JarExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".jar" };
+        private static readonly HashSet<string> DllExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".dll" };
+        private static readonly HashSet<string> PythonInlineSwitches = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "-c", "-m", "-" };
+        private static readonly HashSet<string> PerlRubyInlineSwitches = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "-e", "-E", "-" };
 
         public static PrivilegedScheduledTaskReport GetReport()
         {
@@ -88,8 +114,7 @@ namespace winPEAS.Info.ApplicationInfo
             ISet<string> unprivilegedSids,
             PrivilegedScheduledTaskReport report)
         {
-            if (folder == null || depth > MaxFolderDepth || report.FolderLimitReached ||
-                report.TaskLimitReached || report.FindingLimitReached)
+            if (folder == null || depth > MaxFolderDepth || ShouldStop(report))
             {
                 return;
             }
@@ -110,6 +135,11 @@ namespace winPEAS.Info.ApplicationInfo
                     {
                         using (task)
                         {
+                            if (ShouldStop(report))
+                            {
+                                return;
+                            }
+
                             if (report.TasksInspected >= MaxTasks)
                             {
                                 report.TaskLimitReached = true;
@@ -118,7 +148,7 @@ namespace winPEAS.Info.ApplicationInfo
 
                             report.TasksInspected++;
                             ProcessTask(task, unprivilegedSids, report);
-                            if (report.FindingLimitReached)
+                            if (ShouldStop(report))
                             {
                                 return;
                             }
@@ -142,7 +172,7 @@ namespace winPEAS.Info.ApplicationInfo
                             ProcessFolder(subFolder, depth + 1, unprivilegedSids, report);
                         }
 
-                        if (report.FolderLimitReached || report.TaskLimitReached || report.FindingLimitReached)
+                        if (ShouldStop(report))
                         {
                             return;
                         }
@@ -162,7 +192,7 @@ namespace winPEAS.Info.ApplicationInfo
         {
             try
             {
-                if (task == null || !task.Enabled)
+                if (task == null || !task.Enabled || ShouldStop(report))
                 {
                     return;
                 }
@@ -184,6 +214,11 @@ namespace winPEAS.Info.ApplicationInfo
                     {
                         foreach (TaskAction action in actions)
                         {
+                            if (ShouldStop(report))
+                            {
+                                return;
+                            }
+
                             using (action)
                             {
                                 var execAction = action as TaskAction.ExecAction;
@@ -193,7 +228,7 @@ namespace winPEAS.Info.ApplicationInfo
                                 }
                             }
 
-                            if (report.FindingLimitReached)
+                            if (ShouldStop(report))
                             {
                                 return;
                             }
@@ -225,7 +260,7 @@ namespace winPEAS.Info.ApplicationInfo
                 targets.Add(resolvedExecutable);
             }
 
-            foreach (string referencedPath in ExtractReferencedFilePaths(arguments, workingDirectory))
+            foreach (string referencedPath in ExtractReferencedFilePaths(executable, arguments, workingDirectory))
             {
                 if (targets.Count >= MaxTargetsPerAction)
                 {
@@ -237,6 +272,12 @@ namespace winPEAS.Info.ApplicationInfo
 
             foreach (string target in targets)
             {
+                if (ShouldStop(report))
+                {
+                    return;
+                }
+
+                report.TargetsInspected++;
                 string accessReason = GetWritableTargetReason(target, unprivilegedSids);
                 if (string.IsNullOrEmpty(accessReason))
                 {
@@ -274,7 +315,10 @@ namespace winPEAS.Info.ApplicationInfo
                 normalized.Equals(@"NT AUTHORITY\SYSTEM", StringComparison.OrdinalIgnoreCase);
         }
 
-        internal static List<string> ExtractReferencedFilePaths(string arguments, string workingDirectory)
+        internal static List<string> ExtractReferencedFilePaths(
+            string executable,
+            string arguments,
+            string workingDirectory)
         {
             var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             string expandedArguments = ExpandAndTrim(arguments);
@@ -289,50 +333,164 @@ namespace winPEAS.Info.ApplicationInfo
                 expandedArguments = expandedArguments.Substring(0, MaxArgumentLength);
             }
 
-            foreach (Match match in AbsoluteFileReference.Matches(expandedArguments))
-            {
-                string candidate = CleanCandidatePath(match.Value);
-                if (IsLocalAbsolutePath(candidate))
-                {
-                    paths.Add(candidate);
-                }
+            List<string> tokens = new List<string>(TokenizeArguments(expandedArguments));
+            string executableName = GetFileName(executable).ToLowerInvariant();
 
-                if (paths.Count >= MaxTargetsPerAction)
-                {
-                    return new List<string>(paths);
-                }
+            if (executableName == "powershell.exe" || executableName == "powershell" ||
+                executableName == "pwsh.exe" || executableName == "pwsh")
+            {
+                AddSwitchValue(tokens, new[] { "-file", "-f" }, PowerShellScriptExtensions, expandedWorkingDirectory, paths);
+            }
+            else if (executableName == "cmd.exe" || executableName == "cmd")
+            {
+                AddCommandShellTarget(tokens, expandedWorkingDirectory, paths);
+            }
+            else if (executableName == "wscript.exe" || executableName == "wscript" ||
+                executableName == "cscript.exe" || executableName == "cscript")
+            {
+                AddFirstPositional(tokens, WindowsScriptHostExtensions, expandedWorkingDirectory, paths, null);
+            }
+            else if (executableName == "mshta.exe" || executableName == "mshta")
+            {
+                AddFirstPositional(tokens, HtaExtensions, expandedWorkingDirectory, paths, null);
+            }
+            else if (executableName == "python.exe" || executableName == "python" ||
+                executableName == "pythonw.exe" || executableName == "pythonw" ||
+                Regex.IsMatch(executableName, @"^python\d+(?:\.\d+)?(?:w)?(?:\.exe)?$", RegexOptions.CultureInvariant))
+            {
+                AddFirstPositional(tokens, PythonScriptExtensions, expandedWorkingDirectory, paths, PythonInlineSwitches);
+            }
+            else if (executableName == "perl.exe" || executableName == "perl")
+            {
+                AddFirstPositional(tokens, PerlScriptExtensions, expandedWorkingDirectory, paths, PerlRubyInlineSwitches);
+            }
+            else if (executableName == "ruby.exe" || executableName == "ruby")
+            {
+                AddFirstPositional(tokens, RubyScriptExtensions, expandedWorkingDirectory, paths, PerlRubyInlineSwitches);
+            }
+            else if (executableName == "java.exe" || executableName == "java" ||
+                executableName == "javaw.exe" || executableName == "javaw")
+            {
+                AddSwitchValue(tokens, new[] { "-jar" }, JarExtensions, expandedWorkingDirectory, paths);
+            }
+            else if (executableName == "rundll32.exe" || executableName == "rundll32" ||
+                executableName == "regsvr32.exe" || executableName == "regsvr32")
+            {
+                AddFirstPositional(tokens, DllExtensions, expandedWorkingDirectory, paths, null);
             }
 
-            if (!IsLocalAbsolutePath(expandedWorkingDirectory))
-            {
-                return new List<string>(paths);
-            }
+            return new List<string>(paths);
+        }
 
-            foreach (string token in TokenizeArguments(expandedArguments))
+        private static void AddSwitchValue(
+            IList<string> tokens,
+            IEnumerable<string> switchNames,
+            ISet<string> allowedExtensions,
+            string workingDirectory,
+            ISet<string> paths)
+        {
+            var switches = new HashSet<string>(switchNames, StringComparer.OrdinalIgnoreCase);
+            for (int index = 0; index < tokens.Count; index++)
             {
-                string candidate = CleanCandidatePath(token);
-                if (string.IsNullOrEmpty(candidate) || IsWindowsAbsolutePath(candidate) ||
-                    !ExecutableOrScriptExtensions.Contains(Path.GetExtension(candidate)))
+                string token = tokens[index];
+                if (switches.Contains(token) && index + 1 < tokens.Count)
+                {
+                    AddExecutionCandidate(tokens[index + 1], allowedExtensions, workingDirectory, paths);
+                    return;
+                }
+
+                foreach (string switchName in switches)
+                {
+                    string prefix = switchName + ":";
+                    if (token.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        AddExecutionCandidate(token.Substring(prefix.Length), allowedExtensions, workingDirectory, paths);
+                        return;
+                    }
+                }
+            }
+        }
+
+        private static void AddCommandShellTarget(
+            IList<string> tokens,
+            string workingDirectory,
+            ISet<string> paths)
+        {
+            for (int index = 0; index + 1 < tokens.Count; index++)
+            {
+                if (!tokens[index].Equals("/c", StringComparison.OrdinalIgnoreCase) &&
+                    !tokens[index].Equals("/k", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }
 
-                try
+                int candidateIndex = index + 1;
+                if (tokens[candidateIndex].Equals("call", StringComparison.OrdinalIgnoreCase) &&
+                    candidateIndex + 1 < tokens.Count)
                 {
-                    paths.Add(Path.GetFullPath(Path.Combine(expandedWorkingDirectory, candidate)));
-                }
-                catch
-                {
-                    // Ignore malformed relative paths.
+                    candidateIndex++;
                 }
 
-                if (paths.Count >= MaxTargetsPerAction)
+                AddExecutionCandidate(tokens[candidateIndex].TrimStart('&'), CmdTargetExtensions, workingDirectory, paths);
+                return;
+            }
+        }
+
+        private static void AddFirstPositional(
+            IEnumerable<string> tokens,
+            ISet<string> allowedExtensions,
+            string workingDirectory,
+            ISet<string> paths,
+            ISet<string> terminatingSwitches)
+        {
+            foreach (string token in tokens)
+            {
+                if (terminatingSwitches != null && terminatingSwitches.Contains(token))
                 {
-                    break;
+                    return;
                 }
+
+                if (token.StartsWith("-", StringComparison.Ordinal) || token.StartsWith("/", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                AddExecutionCandidate(token.Split(',')[0], allowedExtensions, workingDirectory, paths);
+                return;
+            }
+        }
+
+        private static void AddExecutionCandidate(
+            string value,
+            ISet<string> allowedExtensions,
+            string workingDirectory,
+            ISet<string> paths)
+        {
+            string candidate = CleanCandidatePath(value);
+            if (string.IsNullOrEmpty(candidate) || !allowedExtensions.Contains(Path.GetExtension(candidate)))
+            {
+                return;
             }
 
-            return new List<string>(paths);
+            if (IsLocalAbsolutePath(candidate))
+            {
+                paths.Add(candidate);
+                return;
+            }
+
+            if (!IsLocalAbsolutePath(workingDirectory))
+            {
+                return;
+            }
+
+            try
+            {
+                paths.Add(Path.GetFullPath(Path.Combine(workingDirectory, candidate)));
+            }
+            catch
+            {
+                // Ignore malformed relative paths.
+            }
         }
 
         private static IEnumerable<string> TokenizeArguments(string arguments)
@@ -405,7 +563,7 @@ namespace winPEAS.Info.ApplicationInfo
 
         private static string GetWritableTargetReason(string displayPath, ISet<string> unprivilegedSids)
         {
-            if (!IsLocalAbsolutePath(displayPath) || unprivilegedSids == null || unprivilegedSids.Count == 0)
+            if (!IsPathOnLocalDrive(displayPath) || unprivilegedSids == null || unprivilegedSids.Count == 0)
             {
                 return null;
             }
@@ -670,6 +828,13 @@ namespace winPEAS.Info.ApplicationInfo
             return value.Trim().Trim('"', '\'').Replace('/', '\\');
         }
 
+        private static string GetFileName(string path)
+        {
+            string candidate = CleanCandidatePath(path) ?? string.Empty;
+            int separator = Math.Max(candidate.LastIndexOf('\\'), candidate.LastIndexOf('/'));
+            return separator >= 0 ? candidate.Substring(separator + 1) : candidate;
+        }
+
         private static bool IsWindowsAbsolutePath(string path)
         {
             return !string.IsNullOrEmpty(path) &&
@@ -680,6 +845,62 @@ namespace winPEAS.Info.ApplicationInfo
         private static bool IsLocalAbsolutePath(string path)
         {
             return IsWindowsAbsolutePath(path) && !path.StartsWith(@"\\", StringComparison.Ordinal);
+        }
+
+        private static bool IsPathOnLocalDrive(string path)
+        {
+            if (!IsLocalAbsolutePath(path))
+            {
+                return false;
+            }
+
+            try
+            {
+                string root = Path.GetPathRoot(path);
+                return !string.IsNullOrEmpty(root) && IsAllowedDriveType(new DriveInfo(root).DriveType);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        internal static bool IsAllowedDriveType(DriveType driveType)
+        {
+            return driveType != DriveType.Network &&
+                driveType != DriveType.NoRootDirectory &&
+                driveType != DriveType.Unknown;
+        }
+
+        private static bool ShouldStop(PrivilegedScheduledTaskReport report)
+        {
+            if (report == null)
+            {
+                return true;
+            }
+
+            return ApplySafetyLimits(report, report.InspectionTimer.ElapsedMilliseconds);
+        }
+
+        internal static bool ApplySafetyLimits(PrivilegedScheduledTaskReport report, long elapsedMilliseconds)
+        {
+            if (report == null)
+            {
+                return true;
+            }
+
+            if (elapsedMilliseconds >= MaxInspectionMilliseconds)
+            {
+                report.TimeLimitReached = true;
+            }
+
+            if (report.TargetsInspected >= MaxTargets)
+            {
+                report.TargetLimitReached = true;
+            }
+
+            return report.FolderLimitReached || report.TaskLimitReached ||
+                report.TargetLimitReached || report.TimeLimitReached || report.FindingLimitReached;
         }
 
     }

--- a/winPEAS/winPEASexe/winPEAS/Info/ApplicationInfo/PrivilegedScheduledTasks.cs
+++ b/winPEAS/winPEASexe/winPEAS/Info/ApplicationInfo/PrivilegedScheduledTasks.cs
@@ -1,0 +1,686 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Text;
+using System.Text.RegularExpressions;
+using winPEAS.TaskScheduler;
+using ScheduledTask = winPEAS.TaskScheduler.Task;
+using TaskAction = winPEAS.TaskScheduler.Action;
+
+namespace winPEAS.Info.ApplicationInfo
+{
+    internal sealed class PrivilegedScheduledTaskFinding
+    {
+        public string TaskPath { get; set; }
+        public string Principal { get; set; }
+        public string Executable { get; set; }
+        public string TargetPath { get; set; }
+        public string AccessReason { get; set; }
+    }
+
+    internal sealed class PrivilegedScheduledTaskReport
+    {
+        public List<PrivilegedScheduledTaskFinding> Findings { get; } = new List<PrivilegedScheduledTaskFinding>();
+        public int FoldersInspected { get; set; }
+        public int TasksInspected { get; set; }
+        public bool FolderLimitReached { get; set; }
+        public bool TaskLimitReached { get; set; }
+        public bool FindingLimitReached { get; set; }
+    }
+
+    internal static class PrivilegedScheduledTasks
+    {
+        internal const int MaxTasks = 2048;
+        internal const int MaxFindings = 64;
+        internal const int MaxFolders = 1024;
+        private const int MaxFolderDepth = 32;
+        private const int MaxTargetsPerAction = 16;
+        private const int MaxArgumentLength = 8192;
+
+        private const uint FileWriteData = 0x00000002;
+        private const uint FileAppendData = 0x00000004;
+        private const uint FileDeleteChild = 0x00000040;
+        private const uint WriteDac = 0x00040000;
+        private const uint WriteOwner = 0x00080000;
+        private const uint GenericWrite = 0x40000000;
+        private const uint GenericAll = 0x10000000;
+
+        private static readonly Regex AbsoluteFileReference = new Regex(
+            @"(?i)(?:[a-z]:\\|\\\\)[^""'\r\n]*?\.(?:exe|com|dll|ps1|psm1|bat|cmd|vbs|vbe|js|jse|wsf|wsh|hta|py|pl|rb|jar)(?=$|[\s,""';)&|])",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        private static readonly HashSet<string> ReplaceableScriptExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".ps1", ".psm1", ".bat", ".cmd", ".vbs", ".vbe", ".js", ".jse",
+            ".wsf", ".wsh", ".hta", ".py", ".pl", ".rb",
+        };
+
+        private static readonly HashSet<string> ExecutableOrScriptExtensions = new HashSet<string>(ReplaceableScriptExtensions, StringComparer.OrdinalIgnoreCase)
+        {
+            ".exe", ".com", ".dll", ".jar",
+        };
+
+        public static PrivilegedScheduledTaskReport GetReport()
+        {
+            var report = new PrivilegedScheduledTaskReport();
+            HashSet<string> unprivilegedSids = GetUnprivilegedTokenSids();
+
+            try
+            {
+                using (TaskFolder root = TaskService.Instance.GetFolder(@"\"))
+                {
+                    ProcessFolder(root, 0, unprivilegedSids, report);
+                }
+            }
+            catch
+            {
+                // Task Scheduler may be unavailable or access-restricted. Other checks should continue quietly.
+            }
+
+            return report;
+        }
+
+        private static void ProcessFolder(
+            TaskFolder folder,
+            int depth,
+            ISet<string> unprivilegedSids,
+            PrivilegedScheduledTaskReport report)
+        {
+            if (folder == null || depth > MaxFolderDepth || report.FolderLimitReached ||
+                report.TaskLimitReached || report.FindingLimitReached)
+            {
+                return;
+            }
+
+            if (report.FoldersInspected >= MaxFolders)
+            {
+                report.FolderLimitReached = true;
+                return;
+            }
+
+            report.FoldersInspected++;
+
+            try
+            {
+                using (TaskCollection tasks = folder.GetTasks())
+                {
+                    foreach (ScheduledTask task in tasks)
+                    {
+                        using (task)
+                        {
+                            if (report.TasksInspected >= MaxTasks)
+                            {
+                                report.TaskLimitReached = true;
+                                return;
+                            }
+
+                            report.TasksInspected++;
+                            ProcessTask(task, unprivilegedSids, report);
+                            if (report.FindingLimitReached)
+                            {
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // An inaccessible task must not prevent inspection of accessible folders.
+            }
+
+            try
+            {
+                using (TaskFolderCollection subFolders = folder.SubFolders)
+                {
+                    foreach (TaskFolder subFolder in subFolders)
+                    {
+                        using (subFolder)
+                        {
+                            ProcessFolder(subFolder, depth + 1, unprivilegedSids, report);
+                        }
+
+                        if (report.FolderLimitReached || report.TaskLimitReached || report.FindingLimitReached)
+                        {
+                            return;
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Some protected folders cannot be enumerated by a standard user.
+            }
+        }
+
+        private static void ProcessTask(
+            ScheduledTask task,
+            ISet<string> unprivilegedSids,
+            PrivilegedScheduledTaskReport report)
+        {
+            try
+            {
+                if (task == null || !task.Enabled)
+                {
+                    return;
+                }
+
+                using (TaskDefinition definition = task.Definition)
+                using (TaskPrincipal principal = definition.Principal)
+                {
+                    string principalName = principal.UserId;
+                    if (string.IsNullOrWhiteSpace(principalName))
+                    {
+                        principalName = principal.Account;
+                    }
+                    if (!IsLocalSystemPrincipal(principalName))
+                    {
+                        return;
+                    }
+
+                    using (ActionCollection actions = definition.Actions)
+                    {
+                        foreach (TaskAction action in actions)
+                        {
+                            using (action)
+                            {
+                                var execAction = action as TaskAction.ExecAction;
+                                if (execAction != null)
+                                {
+                                    ProcessExecAction(task.Path, principalName, execAction, unprivilegedSids, report);
+                                }
+                            }
+
+                            if (report.FindingLimitReached)
+                            {
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Definitions and individual actions can be access-restricted or malformed.
+            }
+        }
+
+        private static void ProcessExecAction(
+            string taskPath,
+            string principal,
+            TaskAction.ExecAction action,
+            ISet<string> unprivilegedSids,
+            PrivilegedScheduledTaskReport report)
+        {
+            string executable = ExpandAndTrim(action.Path);
+            string arguments = ExpandAndTrim(action.Arguments);
+            string workingDirectory = ExpandAndTrim(action.WorkingDirectory);
+            var targets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            string resolvedExecutable = ResolveActionPath(executable, workingDirectory);
+            if (!string.IsNullOrEmpty(resolvedExecutable))
+            {
+                targets.Add(resolvedExecutable);
+            }
+
+            foreach (string referencedPath in ExtractReferencedFilePaths(arguments, workingDirectory))
+            {
+                if (targets.Count >= MaxTargetsPerAction)
+                {
+                    break;
+                }
+
+                targets.Add(referencedPath);
+            }
+
+            foreach (string target in targets)
+            {
+                string accessReason = GetWritableTargetReason(target, unprivilegedSids);
+                if (string.IsNullOrEmpty(accessReason))
+                {
+                    continue;
+                }
+
+                report.Findings.Add(new PrivilegedScheduledTaskFinding
+                {
+                    TaskPath = taskPath,
+                    Principal = principal,
+                    Executable = executable,
+                    TargetPath = target,
+                    AccessReason = accessReason,
+                });
+
+                if (report.Findings.Count >= MaxFindings)
+                {
+                    report.FindingLimitReached = true;
+                    return;
+                }
+            }
+        }
+
+        internal static bool IsLocalSystemPrincipal(string principal)
+        {
+            if (string.IsNullOrWhiteSpace(principal))
+            {
+                return false;
+            }
+
+            string normalized = principal.Trim().Replace('/', '\\');
+            return normalized.Equals("S-1-5-18", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("SYSTEM", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("LocalSystem", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals(@"NT AUTHORITY\SYSTEM", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static List<string> ExtractReferencedFilePaths(string arguments, string workingDirectory)
+        {
+            var paths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            string expandedArguments = ExpandAndTrim(arguments);
+            string expandedWorkingDirectory = ExpandAndTrim(workingDirectory);
+            if (string.IsNullOrEmpty(expandedArguments))
+            {
+                return new List<string>();
+            }
+
+            if (expandedArguments.Length > MaxArgumentLength)
+            {
+                expandedArguments = expandedArguments.Substring(0, MaxArgumentLength);
+            }
+
+            foreach (Match match in AbsoluteFileReference.Matches(expandedArguments))
+            {
+                string candidate = CleanCandidatePath(match.Value);
+                if (IsLocalAbsolutePath(candidate))
+                {
+                    paths.Add(candidate);
+                }
+
+                if (paths.Count >= MaxTargetsPerAction)
+                {
+                    return new List<string>(paths);
+                }
+            }
+
+            if (!IsLocalAbsolutePath(expandedWorkingDirectory))
+            {
+                return new List<string>(paths);
+            }
+
+            foreach (string token in TokenizeArguments(expandedArguments))
+            {
+                string candidate = CleanCandidatePath(token);
+                if (string.IsNullOrEmpty(candidate) || IsWindowsAbsolutePath(candidate) ||
+                    !ExecutableOrScriptExtensions.Contains(Path.GetExtension(candidate)))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    paths.Add(Path.GetFullPath(Path.Combine(expandedWorkingDirectory, candidate)));
+                }
+                catch
+                {
+                    // Ignore malformed relative paths.
+                }
+
+                if (paths.Count >= MaxTargetsPerAction)
+                {
+                    break;
+                }
+            }
+
+            return new List<string>(paths);
+        }
+
+        private static IEnumerable<string> TokenizeArguments(string arguments)
+        {
+            var tokens = new List<string>();
+            var current = new StringBuilder();
+            char quote = '\0';
+
+            foreach (char character in arguments)
+            {
+                if ((character == '"' || character == '\'') && (quote == '\0' || quote == character))
+                {
+                    quote = quote == '\0' ? character : '\0';
+                    continue;
+                }
+
+                if (char.IsWhiteSpace(character) && quote == '\0')
+                {
+                    if (current.Length > 0)
+                    {
+                        tokens.Add(current.ToString());
+                        current.Clear();
+                        if (tokens.Count >= 128)
+                        {
+                            return tokens;
+                        }
+                    }
+                }
+                else
+                {
+                    current.Append(character);
+                }
+            }
+
+            if (current.Length > 0 && tokens.Count < 128)
+            {
+                tokens.Add(current.ToString());
+            }
+
+            return tokens;
+        }
+
+        private static string ResolveActionPath(string executable, string workingDirectory)
+        {
+            if (string.IsNullOrEmpty(executable))
+            {
+                return null;
+            }
+
+            string candidate = CleanCandidatePath(executable);
+            if (IsLocalAbsolutePath(candidate))
+            {
+                return candidate;
+            }
+
+            if (!IsLocalAbsolutePath(workingDirectory))
+            {
+                return null;
+            }
+
+            try
+            {
+                return Path.GetFullPath(Path.Combine(workingDirectory, candidate));
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string GetWritableTargetReason(string displayPath, ISet<string> unprivilegedSids)
+        {
+            if (!IsLocalAbsolutePath(displayPath) || unprivilegedSids == null || unprivilegedSids.Count == 0)
+            {
+                return null;
+            }
+
+            try
+            {
+                string accessPath = GetAccessPath(displayPath);
+                if (File.Exists(accessPath))
+                {
+                    var descriptor = GetFileSecurityDescriptor(accessPath);
+                    string trustee = FindWriteTrustee(descriptor, unprivilegedSids, FileWriteData | WriteDac | WriteOwner);
+                    if (string.IsNullOrEmpty(trustee) && ReplaceableScriptExtensions.Contains(Path.GetExtension(accessPath)))
+                    {
+                        trustee = FindWriteTrustee(descriptor, unprivilegedSids, FileAppendData);
+                    }
+
+                    if (!string.IsNullOrEmpty(trustee))
+                    {
+                        return "file is writable by " + trustee;
+                    }
+
+                    string parent = Path.GetDirectoryName(accessPath);
+                    string replacementTrustee = GetDirectoryReplacementTrustee(parent, unprivilegedSids);
+                    return string.IsNullOrEmpty(replacementTrustee)
+                        ? null
+                        : "parent permits file replacement by " + replacementTrustee;
+                }
+
+                string missingParent = Path.GetDirectoryName(accessPath);
+                if (string.IsNullOrEmpty(missingParent) || !Directory.Exists(missingParent))
+                {
+                    return null;
+                }
+
+                string createTrustee = FindWriteTrustee(
+                    GetDirectorySecurityDescriptor(missingParent),
+                    unprivilegedSids,
+                    FileWriteData | WriteDac | WriteOwner);
+                return string.IsNullOrEmpty(createTrustee)
+                    ? null
+                    : "missing target can be created by " + createTrustee;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string GetDirectoryReplacementTrustee(string directoryPath, ISet<string> unprivilegedSids)
+        {
+            if (string.IsNullOrEmpty(directoryPath) || !Directory.Exists(directoryPath))
+            {
+                return null;
+            }
+
+            RawSecurityDescriptor descriptor = GetDirectorySecurityDescriptor(directoryPath);
+            return FindDirectoryReplacementTrustee(descriptor, unprivilegedSids);
+        }
+
+        internal static string FindDirectoryReplacementTrustee(
+            RawSecurityDescriptor descriptor,
+            ISet<string> unprivilegedSids)
+        {
+            string controlTrustee = FindWriteTrustee(descriptor, unprivilegedSids, WriteDac | WriteOwner);
+            if (!string.IsNullOrEmpty(controlTrustee))
+            {
+                return controlTrustee;
+            }
+
+            foreach (string sid in unprivilegedSids)
+            {
+                var singleSid = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { sid };
+                if (!string.IsNullOrEmpty(FindWriteTrustee(descriptor, singleSid, FileWriteData)) &&
+                    !string.IsNullOrEmpty(FindWriteTrustee(descriptor, singleSid, FileDeleteChild)))
+                {
+                    return sid;
+                }
+            }
+
+            return null;
+        }
+
+        internal static string FindWriteTrustee(
+            RawSecurityDescriptor descriptor,
+            ISet<string> enabledSids,
+            uint desiredRights)
+        {
+            if (descriptor == null || enabledSids == null || enabledSids.Count == 0 || desiredRights == 0)
+            {
+                return null;
+            }
+
+            if ((descriptor.ControlFlags & ControlFlags.DiscretionaryAclPresent) == 0 ||
+                descriptor.DiscretionaryAcl == null)
+            {
+                return enabledSids.Contains("S-1-1-0") ? "S-1-1-0" : null;
+            }
+
+            foreach (uint desiredRight in IndividualRights(desiredRights))
+            {
+                foreach (GenericAce ace in descriptor.DiscretionaryAcl)
+                {
+                    if ((ace.AceFlags & AceFlags.InheritOnly) != 0)
+                    {
+                        continue;
+                    }
+
+                    var qualifiedAce = ace as QualifiedAce;
+                    var knownAce = ace as KnownAce;
+                    if (qualifiedAce == null || knownAce == null || qualifiedAce.SecurityIdentifier == null ||
+                        !enabledSids.Contains(qualifiedAce.SecurityIdentifier.Value) ||
+                        !GrantsRight(unchecked((uint)knownAce.AccessMask), desiredRight))
+                    {
+                        continue;
+                    }
+
+                    if (qualifiedAce.AceQualifier == AceQualifier.AccessDenied)
+                    {
+                        break;
+                    }
+
+                    if (qualifiedAce.AceQualifier == AceQualifier.AccessAllowed)
+                    {
+                        return qualifiedAce.SecurityIdentifier.Value;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static IEnumerable<uint> IndividualRights(uint rights)
+        {
+            uint[] candidates = { FileWriteData, FileAppendData, FileDeleteChild, WriteDac, WriteOwner };
+            foreach (uint candidate in candidates)
+            {
+                if ((rights & candidate) != 0)
+                {
+                    yield return candidate;
+                }
+            }
+        }
+
+        private static bool GrantsRight(uint mask, uint desiredRight)
+        {
+            if ((mask & GenericAll) != 0 || (mask & desiredRight) != 0)
+            {
+                return true;
+            }
+
+            return (mask & GenericWrite) != 0 &&
+                (desiredRight == FileWriteData || desiredRight == FileAppendData);
+        }
+
+        private static RawSecurityDescriptor GetFileSecurityDescriptor(string path)
+        {
+            FileSecurity security = File.GetAccessControl(path, AccessControlSections.Access);
+            return FromBinarySecurityDescriptor(security.GetSecurityDescriptorBinaryForm());
+        }
+
+        private static RawSecurityDescriptor GetDirectorySecurityDescriptor(string path)
+        {
+            DirectorySecurity security = Directory.GetAccessControl(path, AccessControlSections.Access);
+            return FromBinarySecurityDescriptor(security.GetSecurityDescriptorBinaryForm());
+        }
+
+        private static RawSecurityDescriptor FromBinarySecurityDescriptor(byte[] binaryDescriptor)
+        {
+            return binaryDescriptor == null || binaryDescriptor.Length == 0
+                ? null
+                : new RawSecurityDescriptor(binaryDescriptor, 0);
+        }
+
+        private static HashSet<string> GetUnprivilegedTokenSids()
+        {
+            var sids = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "S-1-1-0",      // Everyone
+                "S-1-5-4",      // Interactive
+                "S-1-5-11",     // Authenticated Users
+                "S-1-5-32-545", // BUILTIN\Users
+            };
+
+            try
+            {
+                using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
+                {
+                    var principal = new WindowsPrincipal(identity);
+                    var administratorsSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+                    bool privileged = principal.IsInRole(administratorsSid) ||
+                        (identity.User != null && IsPrivilegedServiceSid(identity.User.Value));
+                    if (!privileged && identity.User != null)
+                    {
+                        sids.Add(identity.User.Value);
+                    }
+
+                    if (identity.Groups != null)
+                    {
+                        foreach (IdentityReference group in identity.Groups)
+                        {
+                            var sid = group as SecurityIdentifier;
+                            if (sid != null && principal.IsInRole(sid) && !sid.Equals(administratorsSid) &&
+                                !IsPrivilegedServiceSid(sid.Value))
+                            {
+                                sids.Add(sid.Value);
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Well-known low-privilege principals still provide useful configuration auditing.
+            }
+
+            return sids;
+        }
+
+        private static bool IsPrivilegedServiceSid(string sid)
+        {
+            return string.Equals(sid, "S-1-5-18", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(sid, "S-1-5-19", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(sid, "S-1-5-20", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string GetAccessPath(string displayPath)
+        {
+            if (!Environment.Is64BitOperatingSystem || Environment.Is64BitProcess)
+            {
+                return displayPath;
+            }
+
+            string systemRoot = Environment.GetEnvironmentVariable("SystemRoot");
+            if (string.IsNullOrEmpty(systemRoot))
+            {
+                return displayPath;
+            }
+
+            string system32 = Path.Combine(systemRoot.TrimEnd('\\'), "System32") + "\\";
+            if (!displayPath.StartsWith(system32, StringComparison.OrdinalIgnoreCase))
+            {
+                return displayPath;
+            }
+
+            return Path.Combine(systemRoot, "Sysnative") + "\\" + displayPath.Substring(system32.Length);
+        }
+
+        private static string ExpandAndTrim(string value)
+        {
+            return string.IsNullOrWhiteSpace(value)
+                ? string.Empty
+                : Environment.ExpandEnvironmentVariables(value).Trim();
+        }
+
+        private static string CleanCandidatePath(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+
+            return value.Trim().Trim('"', '\'').Replace('/', '\\');
+        }
+
+        private static bool IsWindowsAbsolutePath(string path)
+        {
+            return !string.IsNullOrEmpty(path) &&
+                ((path.Length >= 3 && char.IsLetter(path[0]) && path[1] == ':' && path[2] == '\\') ||
+                 path.StartsWith(@"\\", StringComparison.Ordinal));
+        }
+
+        private static bool IsLocalAbsolutePath(string path)
+        {
+            return IsWindowsAbsolutePath(path) && !path.StartsWith(@"\\", StringComparison.Ordinal);
+        }
+
+    }
+}

--- a/winPEAS/winPEASexe/winPEAS/winPEAS.csproj
+++ b/winPEAS/winPEASexe/winPEAS/winPEAS.csproj
@@ -1227,6 +1227,7 @@
     <Compile Include="Info\ApplicationInfo\AutoRuns.cs" />
     <Compile Include="Info\ApplicationInfo\DeviceDrivers.cs" />
     <Compile Include="Info\ApplicationInfo\InstalledPackageInventory.cs" />
+    <Compile Include="Info\ApplicationInfo\PrivilegedScheduledTasks.cs" />
     <Compile Include="Info\ApplicationInfo\SoapClientProxyAnalyzer.cs" />
     <Compile Include="Info\ApplicationInfo\InstalledApps.cs" />
     <Compile Include="Helpers\Beaprint.cs" />


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->

<!-- daily-stats-summary: Proposed one high-impact winpeas vulnerability check. -->

Automated proposal for one new, high-impact `winpeas` vulnerability-detection check.

Agent research and validation summary:
PEASS winpeas new-check agent completed successfully with 57 steps. Agent Comment: Implemented exactly one new winPEAS check: **writable execution targets in enabled LocalSystem scheduled tasks**.

### Why it matters
Windows scheduled tasks can execute programs under the highly privileged LocalSystem account. MITRE classifies scheduled tasks as a privilege-escalation technique and specifically recommends auditing task permission weaknesses. [Microsoft documents the SYSTEM execution context](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/schtasks-create), while [MITRE ATT&CK T1053.005](https://attack.mitre.org/techniques/T1053/005/) identifies permission weaknesses in scheduled tasks as escalation opportunities.

### Detection behavior
The passive check:

- Enumerates enabled tasks whose principal is LocalSystem/SYSTEM.
- Examines `ExecAction.Path`, `Arguments`, and `WorkingDirectory`, as defined by the [Microsoft ExecAction API](https://learn.microsoft.com/en-us/windows/win32/taskschd/execaction).
- Detects writable executables and referenced scripts, including scripts hidden in arguments.
- Evaluates effective low-privilege ACL grants while honoring deny ACEs.
- Detects direct writes, script appends, writable missing targets, and parent-directory replacement rights.
- Avoids UNC access and secret argument output.
- Is read-only and bounded to 1,024 folders, 2,048 tasks, 16 targets per action, and 64 findings.

### Files changed
- `winPEAS/winPEASexe/winPEAS/Checks/ApplicationsInfo.cs`
- `winPEAS/winPEASexe/winPEAS/Info/ApplicationInfo/PrivilegedScheduledTasks.cs`
- `winPEAS/winPEASexe/winPEAS/winPEAS.csproj`
- `winPEAS/winPEASexe/Tests/PrivilegedScheduledTaskTests.cs`
- `winPEAS/winPEASexe/Tests/winPEAS.Tests.csproj`

Tests cover SYSTEM principal recognition, argument path extraction, deny-before-allow ACL behavior, and directory replacement requirements.

### Validation
- Complete diff and `git diff --check`: passed.
- Project XML and compile-item validation: passed.
- C# syntax parsing for all changed sources: passed.
- Referenced Task Scheduler types and registration reviewed.
- No .NET, Mono, MSBuild, or C# compiler is installed locally, so the Windows build and MSTest suite could not be executed. No claim of local MSBuild validation is made.

The required `chack_tools-save_discovered_vulnerability` MCP tool was not exposed in this runtime, so an external finding record could not be saved.

Generated by the PEASS New Vulnerability Checks workflow. This PR must pass PEASS PR-tests and normal Chack-Agent review.
