### PR TITLE
new-check(winpeas): add high-impact vulnerability detection

### DIFF
--- a/winPEAS/winPEASexe/Tests/SccmNetworkAccessAccountTests.cs
+++ b/winPEAS/winPEASexe/Tests/SccmNetworkAccessAccountTests.cs
@@ -1,0 +1,44 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using winPEAS.Info.WindowsCreds;
+
+namespace winPEAS.Tests
+{
+    [TestClass]
+    public class SccmNetworkAccessAccountTests
+    {
+        [TestMethod]
+        public void ReportsConfiguredPoliciesWithoutReadingSecretValues()
+        {
+            SccmNetworkAccessAccountReport report = SccmNetworkAccessAccount.GetReport(() => 2);
+
+            Assert.AreEqual(SccmNetworkAccessAccountStatus.Configured, report.Status);
+            Assert.AreEqual(2, report.AccountCount);
+            Assert.IsFalse(report.LimitReached);
+            Assert.AreEqual(
+                "SELECT SiteSettingsKey FROM CCM_NetworkAccessAccount",
+                SccmNetworkAccessAccount.MetadataOnlyQuery);
+        }
+
+        [TestMethod]
+        public void BoundsTheNumberOfReportedPolicies()
+        {
+            SccmNetworkAccessAccountReport report = SccmNetworkAccessAccount.GetReport(
+                () => SccmNetworkAccessAccount.MaxAccounts + 1);
+
+            Assert.AreEqual(SccmNetworkAccessAccount.MaxAccounts, report.AccountCount);
+            Assert.IsTrue(report.LimitReached);
+        }
+
+        [TestMethod]
+        public void DistinguishesNoPolicyFromAccessDenied()
+        {
+            SccmNetworkAccessAccountReport absent = SccmNetworkAccessAccount.GetReport(() => 0);
+            SccmNetworkAccessAccountReport denied = SccmNetworkAccessAccount.GetReport(
+                () => throw new UnauthorizedAccessException());
+
+            Assert.AreEqual(SccmNetworkAccessAccountStatus.NotConfigured, absent.Status);
+            Assert.AreEqual(SccmNetworkAccessAccountStatus.AccessDenied, denied.Status);
+        }
+    }
+}

--- a/winPEAS/winPEASexe/Tests/winPEAS.Tests.csproj
+++ b/winPEAS/winPEASexe/Tests/winPEAS.Tests.csproj
@@ -99,6 +99,7 @@
   <ItemGroup>
     <Compile Include="ArgumentParsingTests.cs" />
     <Compile Include="RegistryHiveExposureTests.cs" />
+    <Compile Include="SccmNetworkAccessAccountTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SmokeTests.cs" />
   </ItemGroup>

--- a/winPEAS/winPEASexe/winPEAS/Checks/WindowsCreds.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/WindowsCreds.cs
@@ -8,6 +8,7 @@ using System.Xml;
 using winPEAS.Helpers;
 using winPEAS.Helpers.CredentialManager;
 using winPEAS.Helpers.Registry;
+using winPEAS.Info.WindowsCreds;
 using winPEAS.Info.WindowsCreds.AppCmd;
 using winPEAS.KnownFileCreds;
 using winPEAS.KnownFileCreds.Kerberos;
@@ -488,6 +489,9 @@ namespace winPEAS.Checks
             try
             {
                 Beaprint.MainPrint("Enumerating SSCM - System Center Configuration Manager settings", "T1552.001");
+                Beaprint.LinkPrint(
+                    "https://specterops.io/blog/2022/06/28/the-phantom-credentials-of-sccm-why-the-naa-wont-die/",
+                    "Network Access Account policies place recoverable domain credential material on SCCM clients; prefer Enhanced HTTP and least privilege.");
 
                 var server = RegistryHelper.GetRegValue("HKLM", @"SOFTWARE\Microsoft\CCMSetup", "LastValidMP");
                 var siteCode = RegistryHelper.GetRegValue("HKLM", @"SOFTWARE\Microsoft\SMS\Mobile Client", "AssignedSiteCode");
@@ -500,6 +504,28 @@ namespace winPEAS.Checks
                                                  $"     Site code:                         {siteCode}\n" +
                                                  $"     Product version:                   {productVersion}\n" +
                                                  $"     Last Successful Install Params:    {lastSuccessfulInstallParams}\n");
+                }
+
+                SccmNetworkAccessAccountReport naaReport = SccmNetworkAccessAccount.GetReport();
+                switch (naaReport.Status)
+                {
+                    case SccmNetworkAccessAccountStatus.Configured:
+                        string count = naaReport.LimitReached
+                            ? $"{naaReport.AccountCount} or more"
+                            : naaReport.AccountCount.ToString();
+                        Beaprint.BadPrint($"     SCCM Network Access Account credential policies cached in WMI: {count}");
+                        Beaprint.GrayPrint("       Only non-secret instance metadata was queried; credential blobs were not read or displayed.");
+                        Beaprint.BadPrint("       A local administrator or SYSTEM can recover these domain credentials. Remove or disable unused accounts and review their rights.");
+                        break;
+                    case SccmNetworkAccessAccountStatus.NotConfigured:
+                        Beaprint.GoodPrint("     No active SCCM Network Access Account credential policy is exposed through WMI.");
+                        break;
+                    case SccmNetworkAccessAccountStatus.AccessDenied:
+                        Beaprint.GrayPrint("     SCCM policy WMI access was denied; an elevated context is required to determine whether Network Access Account credentials are cached.");
+                        break;
+                    default:
+                        Beaprint.GrayPrint("     SCCM Network Access Account policy could not be queried in the current environment.");
+                        break;
                 }
             }
             catch (Exception ex)

--- a/winPEAS/winPEASexe/winPEAS/Checks/WindowsCreds.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/WindowsCreds.cs
@@ -211,7 +211,7 @@ namespace winPEAS.Checks
             {
                 Beaprint.MainPrint("Saved RDP connections", "T1552.002");
 
-                List<Dictionary<string, string>> rdps_info = RemoteDesktop.GetSavedRDPConnections();
+                List<Dictionary<string, string>> rdps_info = KnownFileCreds.RemoteDesktop.GetSavedRDPConnections();
                 if (rdps_info.Count > 0)
                     Beaprint.NoColorPrint(string.Format("    {0,-20}{1,-55}{2}", "Host", "Username Hint", "User SID"));
                 else
@@ -302,7 +302,7 @@ namespace winPEAS.Checks
                     "Checking for RDCMan Settings Files",
                     "T1552.001",
                     RdcManLink,
-                    RemoteDesktop.GetRDCManFiles,
+                    KnownFileCreds.RemoteDesktop.GetRDCManFiles,
                     linkComment: "Dump credentials from Remote Desktop Connection Manager");
 
                 if (rdcFiles.Count > 0)

--- a/winPEAS/winPEASexe/winPEAS/Info/WindowsCreds/SccmNetworkAccessAccount.cs
+++ b/winPEAS/winPEASexe/winPEAS/Info/WindowsCreds/SccmNetworkAccessAccount.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Management;
+using System.Runtime.InteropServices;
+
+namespace winPEAS.Info.WindowsCreds
+{
+    internal enum SccmNetworkAccessAccountStatus
+    {
+        NotConfigured,
+        Configured,
+        AccessDenied,
+        Unavailable,
+    }
+
+    internal sealed class SccmNetworkAccessAccountReport
+    {
+        public SccmNetworkAccessAccountStatus Status { get; set; }
+        public int AccountCount { get; set; }
+        public bool LimitReached { get; set; }
+    }
+
+    internal static class SccmNetworkAccessAccount
+    {
+        internal const int MaxAccounts = 10;
+        internal const string PolicyNamespace = @"root\ccm\Policy\Machine\ActualConfig";
+        internal const string MetadataOnlyQuery = "SELECT SiteSettingsKey FROM CCM_NetworkAccessAccount";
+
+        private const int WbemAccessDenied = unchecked((int)0x80041003);
+        private const int Win32AccessDenied = unchecked((int)0x80070005);
+
+        public static SccmNetworkAccessAccountReport GetReport()
+        {
+            return GetReport(QueryAccountCount);
+        }
+
+        internal static SccmNetworkAccessAccountReport GetReport(Func<int> accountCountQuery)
+        {
+            try
+            {
+                int accountCount = accountCountQuery();
+                if (accountCount <= 0)
+                {
+                    return new SccmNetworkAccessAccountReport
+                    {
+                        Status = SccmNetworkAccessAccountStatus.NotConfigured,
+                    };
+                }
+
+                return new SccmNetworkAccessAccountReport
+                {
+                    Status = SccmNetworkAccessAccountStatus.Configured,
+                    AccountCount = Math.Min(accountCount, MaxAccounts),
+                    LimitReached = accountCount > MaxAccounts,
+                };
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return AccessDeniedReport();
+            }
+            catch (ManagementException ex) when (
+                ex.ErrorCode == ManagementStatus.InvalidNamespace ||
+                ex.ErrorCode == ManagementStatus.InvalidClass)
+            {
+                return new SccmNetworkAccessAccountReport
+                {
+                    Status = SccmNetworkAccessAccountStatus.NotConfigured,
+                };
+            }
+            catch (ManagementException ex) when (ex.ErrorCode == ManagementStatus.AccessDenied)
+            {
+                return AccessDeniedReport();
+            }
+            catch (COMException ex) when (
+                ex.ErrorCode == WbemAccessDenied ||
+                ex.ErrorCode == Win32AccessDenied)
+            {
+                return AccessDeniedReport();
+            }
+            catch
+            {
+                return new SccmNetworkAccessAccountReport
+                {
+                    Status = SccmNetworkAccessAccountStatus.Unavailable,
+                };
+            }
+        }
+
+        private static int QueryAccountCount()
+        {
+            var options = new EnumerationOptions
+            {
+                DirectRead = true,
+                ReturnImmediately = true,
+                Rewindable = false,
+            };
+
+            using (var searcher = new ManagementObjectSearcher(
+                PolicyNamespace,
+                MetadataOnlyQuery,
+                options))
+            using (ManagementObjectCollection accounts = searcher.Get())
+            {
+                int accountCount = 0;
+                foreach (ManagementObject account in accounts)
+                {
+                    using (account)
+                    {
+                        accountCount++;
+                    }
+
+                    if (accountCount > MaxAccounts)
+                    {
+                        break;
+                    }
+                }
+
+                return accountCount;
+            }
+        }
+
+        private static SccmNetworkAccessAccountReport AccessDeniedReport()
+        {
+            return new SccmNetworkAccessAccountReport
+            {
+                Status = SccmNetworkAccessAccountStatus.AccessDenied,
+            };
+        }
+    }
+}

--- a/winPEAS/winPEASexe/winPEAS/winPEAS.csproj
+++ b/winPEAS/winPEASexe/winPEAS/winPEAS.csproj
@@ -1328,6 +1328,7 @@
     <Compile Include="Info\WindowsCreds\RDPServerSettings.cs" />
     <Compile Include="Info\WindowsCreds\RDPSettingsInfo.cs" />
     <Compile Include="Info\WindowsCreds\RemoteDesktop.cs" />
+    <Compile Include="Info\WindowsCreds\SccmNetworkAccessAccount.cs" />
     <Compile Include="InterestingFiles\GPP.cs" />
     <Compile Include="InterestingFiles\InterestingFiles.cs" />
     <Compile Include="InterestingFiles\Unattended.cs" />


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->

<!-- daily-stats-summary: Proposed one high-impact winpeas vulnerability check. -->

Automated proposal for one new, high-impact `winpeas` vulnerability-detection check.

Agent research and validation summary:
PEASS winpeas new-check agent completed successfully with 34 steps. Agent Comment: ## Implemented check

**SCCM Network Access Account credential-policy exposure**

Configuration Manager distributes DPAPI-protected NAA domain credentials to managed clients. Elevated local users can recover them, enabling credential access and potentially broad lateral movement when the account is overprivileged. Microsoft recommends Enhanced HTTP where possible and minimal NAA permissions. [Microsoft guidance](https://learn.microsoft.com/en-us/intune/configmgr/core/plan-design/hierarchy/accounts#network-access-account), [SpecterOps research](https://specterops.io/blog/2022/06/28/the-phantom-credentials-of-sccm-why-the-naa-wont-die/), [upstream SharpDPAPI implementation](https://github.com/GhostPack/SharpDPAPI/blob/master/SharpDPAPI/Commands/SCCM.cs).

### Detection

The existing SCCM credential subsection now:

- Queries `root\ccm\Policy\Machine\ActualConfig`.
- Uses metadata-only WQL: `SELECT SiteSettingsKey FROM CCM_NetworkAccessAccount`.
- Never reads, decrypts, or displays credential blobs.
- Caps enumeration at 10 reported policies.
- Distinguishes configured, absent, access-denied, and unavailable states.
- Disposes all WMI search and result objects.

This was selected after reviewing existing checks, history, remote branches, and open PRs—including avoiding duplication of the pending SYSTEM scheduled-task check.

### Files changed

- `Checks/WindowsCreds.cs`
- `Info/WindowsCreds/SccmNetworkAccessAccount.cs`
- `winPEAS/winPEAS.csproj`
- `Tests/SccmNetworkAccessAccountTests.cs`
- `Tests/winPEAS.Tests.csproj`

### Validation

- `git diff --check` passed.
- Project XML parsing and source inclusion checks passed.
- Helper and regression tests compiled warning-free against `System.Management`.
- Deterministic harness covered configured, absent, bounded, access-denied, and unavailable states.
- Non-Windows unavailable-environment handling passed quietly.
- Complete diff received whitespace, resource-disposal, secret-exclusion, string/path, and compatibility review.

Windows/MSBuild was unavailable locally; the PEASS Windows PR workflow remains the authoritative full build and test validation.

Generated by the PEASS New Vulnerability Checks workflow. This PR must pass PEASS PR-tests and normal Chack-Agent review.
