### PR TITLE
new-check(linpeas): add high-impact vulnerability detection

### DIFF
--- a/linPEAS/builder/linpeas_parts/1_system_information/17_Kernel_Modules.sh
+++ b/linPEAS/builder/linpeas_parts/1_system_information/17_Kernel_Modules.sh
@@ -1,21 +1,22 @@
 # Title: System Information - Kernel Modules
 # ID: SY_Kernel_Modules
 # Author: Carlos Polop
-# Last Update: 07-03-2024
+# Last Update: 24-08-2026
 # Description: Check for kernel module vulnerabilities and misconfigurations that could lead to privilege escalation:
 #   - Loaded kernel modules with known vulnerabilities
 #   - Kernel modules with weak permissions that could be modified
 #   - Ability to load kernel modules as unprivileged user
 #   - Missing kernel module signing requirements
+#   - CIFSwitch (CVE-2026-46243) attack-chain exposure
 #   - Exploitation methods:
 #     * Vulnerable modules: Use known exploits for vulnerable kernel modules
 #     * Weak permissions: Modify kernel modules to inject malicious code
 #     * Module loading: Load malicious kernel modules to get root access
 #     * Common vulnerable modules: nf_tables, eBPF, overlayfs, etc.
 # License: GNU GPL
-# Version: 1.0
-# Mitre: T1547.006
-# Functions Used: print_2title, print_3title
+# Version: 1.1
+# Mitre: T1547.006,T1068
+# Functions Used: checkCIFSwitchCVE202646243, print_2title, print_3title
 # Global Variables: 
 # Initial Functions:
 # Generated Global Variables:
@@ -24,6 +25,7 @@
 
 echo ""
 print_2title "Kernel Modules Information" "T1547.006"
+checkCIFSwitchCVE202646243
 # List loaded kernel modules
 if [ "$EXTRA_CHECKS" ] || [ "$DEBUG" ]; then
     print_3title "Loaded kernel modules" "T1547.006"

--- a/linPEAS/builder/linpeas_parts/functions/checkCIFSwitchCVE202646243.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkCIFSwitchCVE202646243.sh
@@ -1,0 +1,99 @@
+# Title: Functions - checkCIFSwitchCVE202646243
+# ID: checkCIFSwitchCVE202646243
+# Author: Chack Agent
+# Last Update: 24-08-2026
+# Description: Passively identify systems exposing the complete CIFSwitch (CVE-2026-46243) cifs.spnego upcall chain.
+# License: GNU GPL
+# Version: 1.0
+# Mitre: T1068
+# Functions Used: print_3title, print_info
+# Global Variables: $E, $ROOT_FOLDER, $SED_LIGHT_CYAN, $SED_RED_YELLOW
+# Initial Functions:
+# Generated Global Variables: $cs46243_config, $cs46243_helper, $cs46243_helper_host, $cs46243_kallsyms, $cs46243_kernel, $cs46243_major, $cs46243_minor, $cs46243_modules, $cs46243_patch, $cs46243_request_key, $cs46243_root
+# Fat linpeas: 0
+# Small linpeas: 1
+
+
+cs46243_kernel_is_fixed() {
+  cs46243_kernel="${1%%-*}"
+  cs46243_major="$(printf '%s' "$cs46243_kernel" | cut -d. -f1)"
+  cs46243_minor="$(printf '%s' "$cs46243_kernel" | cut -d. -f2)"
+  cs46243_patch="$(printf '%s' "$cs46243_kernel" | cut -d. -f3)"
+
+  case "$cs46243_major:$cs46243_minor:$cs46243_patch" in
+    *[!0-9:]*|::*|*:|:*) return 1 ;;
+  esac
+
+  [ "$cs46243_major" -gt 7 ] && return 0
+  if [ "$cs46243_major" -eq 7 ]; then
+    [ "$cs46243_minor" -ge 1 ] && return 0
+    [ "$cs46243_minor" -eq 0 ] && [ "$cs46243_patch" -ge 11 ] && return 0
+    return 1
+  fi
+
+  [ "$cs46243_major" -lt 2 ] && return 0
+  if [ "$cs46243_major" -eq 2 ]; then
+    [ "$cs46243_minor" -lt 6 ] && return 0
+    [ "$cs46243_minor" -eq 6 ] && [ "$cs46243_patch" -lt 24 ] && return 0
+    return 1
+  fi
+
+  case "$cs46243_major.$cs46243_minor" in
+    5.10) [ "$cs46243_patch" -ge 258 ] ;;
+    5.15) [ "$cs46243_patch" -ge 209 ] ;;
+    6.1) [ "$cs46243_patch" -ge 175 ] ;;
+    6.6) [ "$cs46243_patch" -ge 142 ] ;;
+    6.12) [ "$cs46243_patch" -ge 92 ] ;;
+    6.18) [ "$cs46243_patch" -ge 34 ] ;;
+    *) return 1 ;;
+  esac
+}
+
+checkCIFSwitchCVE202646243() {
+  [ "$(uname -s 2>/dev/null)" = "Linux" ] || return 0
+
+  cs46243_root="${ROOT_FOLDER:-/}"
+  case "$cs46243_root" in
+    */) ;;
+    *) cs46243_root="${cs46243_root}/" ;;
+  esac
+
+  cs46243_modules="${cs46243_root}proc/modules"
+  if ! [ -d "${cs46243_root}sys/module/cifs" ]; then
+    [ -r "$cs46243_modules" ] && grep -q '^cifs[[:space:]]' "$cs46243_modules" 2>/dev/null || return 0
+  fi
+
+  cs46243_config=""
+  cs46243_helper=""
+  # request-key reads the drop-in directory before the main file.
+  for cs46243_config in "${cs46243_root}"etc/request-key.d/*.conf "${cs46243_root}etc/request-key.conf"; do
+    [ -r "$cs46243_config" ] || continue
+    cs46243_helper="$(awk '$1 == "create" && $2 == "cifs.spnego" && $5 ~ /(^|\/)cifs\.upcall$/ { print $5; exit }' "$cs46243_config" 2>/dev/null)"
+    [ "$cs46243_helper" ] && break
+  done
+  [ "$cs46243_helper" ] || return 0
+
+  case "$cs46243_helper" in
+    /*) cs46243_helper_host="${cs46243_root}${cs46243_helper#/}" ;;
+    *) cs46243_helper_host="$cs46243_helper" ;;
+  esac
+  [ -x "$cs46243_helper_host" ] || return 0
+
+  cs46243_request_key="${cs46243_root}sbin/request-key"
+  [ -x "$cs46243_request_key" ] || return 0
+
+  cs46243_kallsyms="${cs46243_root}proc/kallsyms"
+  if [ -r "$cs46243_kallsyms" ] && grep -q '[[:space:]]cifs_spnego_key_vet_description' "$cs46243_kallsyms" 2>/dev/null; then
+    return
+  fi
+
+  cs46243_kernel="$(cat "${cs46243_root}proc/sys/kernel/osrelease" 2>/dev/null)"
+  [ "$cs46243_kernel" ] || cs46243_kernel="$(uname -r 2>/dev/null)"
+  cs46243_kernel_is_fixed "$cs46243_kernel" && return
+
+  print_3title "CIFSwitch attack chain (CVE-2026-46243)" "T1068"
+  print_info "https://access.redhat.com/security/vulnerabilities/RHSB-2026-005"
+  echo "Loaded CIFS module + active cifs.spnego rule + executable request-key/cifs.upcall helpers" | sed -${E} "s,.*,${SED_RED_YELLOW},"
+  echo "Kernel $cs46243_kernel does not expose the upstream cifs.spnego validation marker; vendor backports should be verified" | sed -${E} "s,.*,${SED_LIGHT_CYAN},"
+  echo "Rule: $cs46243_config -> $cs46243_helper"
+}

--- a/linPEAS/tests/test_cifswitch.py
+++ b/linPEAS/tests/test_cifswitch.py
@@ -1,0 +1,163 @@
+import os
+import shlex
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class CIFSwitchCVE202646243Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.repo_root = Path(__file__).resolve().parents[2]
+        cls.function_file = (
+            cls.repo_root
+            / "linPEAS"
+            / "builder"
+            / "linpeas_parts"
+            / "functions"
+            / "checkCIFSwitchCVE202646243.sh"
+        )
+
+    def _make_root(self, base, kernel="6.12.91", patch_marker=False, active_rule=True):
+        root = base / "root"
+        (root / "sys" / "module" / "cifs").mkdir(parents=True)
+        (root / "proc" / "sys" / "kernel").mkdir(parents=True)
+        (root / "proc" / "sys" / "kernel" / "osrelease").write_text(
+            f"{kernel}\n", encoding="utf-8"
+        )
+        kallsyms = "0000000000000000 t unrelated_symbol\n"
+        if patch_marker:
+            kallsyms += "0000000000000000 t cifs_spnego_key_vet_description\n"
+        (root / "proc" / "kallsyms").write_text(kallsyms, encoding="utf-8")
+
+        (root / "etc" / "request-key.d").mkdir(parents=True)
+        prefix = "" if active_rule else "# "
+        (root / "etc" / "request-key.d" / "cifs.conf").write_text(
+            f"{prefix}create cifs.spnego * * /usr/sbin/cifs.upcall %k\n",
+            encoding="utf-8",
+        )
+
+        helper = root / "usr" / "sbin" / "cifs.upcall"
+        helper.parent.mkdir(parents=True)
+        helper.write_text('#!/bin/sh\ntouch "$EXECUTED_MARKER"\n', encoding="utf-8")
+        helper.chmod(0o755)
+        request_key = root / "sbin" / "request-key"
+        request_key.parent.mkdir(parents=True)
+        request_key.write_text('#!/bin/sh\ntouch "$EXECUTED_MARKER"\n', encoding="utf-8")
+        request_key.chmod(0o755)
+        return root
+
+    def _run_check(self, root):
+        marker = root.parent / "executed"
+        env = os.environ.copy()
+        env["EXECUTED_MARKER"] = str(marker)
+        body = "\n".join(
+            [
+                f"ROOT_FOLDER={shlex.quote(str(root))}",
+                "E=E",
+                "SED_RED_YELLOW='&'",
+                "SED_LIGHT_CYAN='&'",
+                'print_3title() { echo "TITLE: $1"; }',
+                "print_info() { :; }",
+                f". {shlex.quote(str(self.function_file))}",
+                "checkCIFSwitchCVE202646243",
+            ]
+        )
+        result = subprocess.run(
+            ["sh", "-c", body],
+            cwd=str(self.repo_root),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result, marker
+
+    def test_complete_vulnerable_chain_is_reported_without_executing_helper(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir))
+            result, marker = self._run_check(root)
+            self.assertFalse(marker.exists(), "cifs.upcall must never be executed")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("TITLE: CIFSwitch attack chain (CVE-2026-46243)", result.stdout)
+        self.assertIn("Loaded CIFS module + active cifs.spnego rule", result.stdout)
+
+    def test_backported_patch_marker_suppresses_finding(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir), patch_marker=True)
+            result, _ = self._run_check(root)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual("", result.stdout)
+
+    def test_fixed_upstream_stable_version_suppresses_finding(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir), kernel="6.12.92")
+            result, _ = self._run_check(root)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual("", result.stdout)
+
+    def test_upstream_fixed_version_boundaries(self):
+        cases = {
+            "2.6.23": True,
+            "2.6.24": False,
+            "5.10.257": False,
+            "5.10.258": True,
+            "5.15.208": False,
+            "5.15.209": True,
+            "6.1.174": False,
+            "6.1.175": True,
+            "6.6.141": False,
+            "6.6.142": True,
+            "6.12.91": False,
+            "6.12.92": True,
+            "6.18.33": False,
+            "6.18.34": True,
+            "7.0.10": False,
+            "7.0.11": True,
+            "7.1.0": True,
+        }
+        checks = [
+            f"cs46243_kernel_is_fixed {shlex.quote(version)} && "
+            f"echo {version}=yes || echo {version}=no"
+            for version in cases
+        ]
+        body = "\n".join(
+            [f". {shlex.quote(str(self.function_file))}"] + checks
+        )
+        result = subprocess.run(
+            ["sh", "-c", body],
+            cwd=str(self.repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for version, fixed in cases.items():
+            expected = "yes" if fixed else "no"
+            self.assertIn(f"{version}={expected}", result.stdout)
+
+    def test_inactive_upcall_rule_suppresses_finding(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir), active_rule=False)
+            result, _ = self._run_check(root)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual("", result.stdout)
+
+    def test_unloaded_cifs_module_suppresses_finding(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir))
+            (root / "sys" / "module" / "cifs").rmdir()
+            result, _ = self._run_check(root)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual("", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->

<!-- daily-stats-summary: Proposed one high-impact linpeas vulnerability check. -->

Automated proposal for one new, high-impact `linpeas` vulnerability-detection check.

Agent research and validation summary:
PEASS linpeas new-check agent completed successfully with 33 steps. Agent Comment: ## Implemented check

**CIFSwitch — CVE-2026-46243**

This high-impact Linux kernel flaw lets a low-privileged local user abuse forged `cifs.spnego` requests to execute code as root. It affects common SMB/Active Directory configurations and impacted RHEL 6–10. [Red Hat advisory](https://access.redhat.com/security/vulnerabilities/RHSB-2026-005), [Ubuntu CVE record](https://ubuntu.com/security/CVE-2026-46243).

### Detection behavior

The new passive check reports only when the complete attack surface exists:

- CIFS kernel module is loaded.
- An active `cifs.spnego` rule invokes `cifs.upcall`.
- `request-key` and `cifs.upcall` are executable.
- The kernel lacks the upstream `cifs_spnego_key_vet_description` patch marker.
- The kernel is below the official fixed stable-version boundary.

It only reads local files and `/proc`/`/sys`; it never invokes either privileged helper or triggers an upcall. The patch marker comes directly from the [upstream kernel fix](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=3da1fdf4efbc490041eb4f836bf596201203f8f2). The rule format was cross-checked against the [cifs.upcall documentation](https://man7.org/linux/man-pages/man8/cifs.upcall.8.html).

### Files changed

- `linPEAS/builder/linpeas_parts/1_system_information/17_Kernel_Modules.sh`
- `linPEAS/builder/linpeas_parts/functions/checkCIFSwitchCVE202646243.sh`
- `linPEAS/tests/test_cifswitch.py`

### Validation

- Modified shell files passed `sh -n`.
- Focused CIFSwitch tests: **6 passed**.
- Metadata suite: **8 passed**.
- Full linPEAS test discovery: **38 passed**.
- Builder succeeded to `/tmp/linpeas_new_check.sh`.
- Generated script passed `sh -n` and contains exactly one check definition and invocation.
- `git diff --check` passed; no generated repository artifacts were added.

Generated by the PEASS New Vulnerability Checks workflow. This PR must pass PEASS PR-tests and normal Chack-Agent review.
