### PR TITLE
fix(parsers): render top-level section infos in json2html

### DIFF
--- a/parsers/json2html.py
+++ b/parsers/json2html.py
@@ -23,14 +23,28 @@ def parse_json(json_data: dict) -> str:
         i = i + 1
         for key1, value1 in value.items():
 
-            if type(value1) == list:
+            if key1 == "infos":
+                body += "<i>" + parse_infos(value1) + "</i>"
+            elif type(value1) == list:
                 body += parse_list(value1)
 
-            if type(value1) == dict:
+            elif type(value1) == dict:
                 body += parse_dict(value1)
         body += "\t\t\t</div>\n"
 
     return body
+
+
+def parse_infos(json_infos: list) -> str:
+    """Parse the given list of info strings from the given json adding them to the HTML file"""
+
+    infos = []
+    for info in json_infos:
+        if info.startswith("http"):
+            infos.append(f"<a href='{html.escape(info)}'>{html.escape(info)}</a><br>\n")
+        else:
+            infos.append(html.escape(str(info)) + "<br>\n")
+    return "".join(infos)
 
 
 def parse_dict(json_dict: dict) -> str:
@@ -39,19 +53,12 @@ def parse_dict(json_dict: dict) -> str:
     dict_text = ""
     for key, value in json_dict.items():
         n = next(_section_ids)
-        infos = []
-        for info in value["infos"]:
-            if info.startswith("http"):
-                infos.append(f"<a href='{html.escape(info)}'>{html.escape(info)}</a><br>\n")
-            else:
-                infos.append(html.escape(str(info)) + "<br>\n")
-
         dict_text += (
             f'\t\t<button type="button" class="btn1" data-toggle="collapse" data-target="#lines{n}">'
             + html.escape(key)
             + "</button><br>\n"
         )
-        dict_text += "<i>" + "".join(infos) + "</i>"
+        dict_text += "<i>" + parse_infos(value["infos"]) + "</i>"
         dict_text += f'<div id="lines{n}" class="collapse1">\n'
 
         if value["lines"]:

--- a/parsers/json2pdf.py
+++ b/parsers/json2pdf.py
@@ -86,11 +86,19 @@ def build_main_section(section, title, level=1):
     # Print info if any
     if show_section and has_links:
         for info in section["infos"]:
-            words = info.split() 
+            words = info.split()
             # Join all lines and encode any links that might be present.
-            words = map(lambda word: f'<a href="{word}" color="blue">{word}</a>' if "http" in word else word, words)
+            # Every word must be escaped before it reaches the Paragraph,
+            # reportlab parses the text as mini-HTML and unescaped angle
+            # brackets or quotes from the scanned output break the document.
+            words = map(
+                lambda word: f'<a href="{html.escape(word)}" color="blue">{html.escape(word)}</a>'
+                if "http" in word
+                else html.escape(word),
+                words,
+            )
             words = " ".join(words)
-            elements.append(Paragraph(words, style=styles["info"] ))
+            elements.append(Paragraph(words, style=styles["info"]))
 
   # Print lines if any
     if "lines" in section.keys() and len(section["lines"]) > 1:

--- a/parsers/peas2json.py
+++ b/parsers/peas2json.py
@@ -61,7 +61,7 @@ def get_colors(line: str) -> dict:
                 # For each potential color, find the string before any possible color terminatio
                 for potential_color_str in split_color:
                     color_str1 = potential_color_str.split('\x1b')[0]
-                    color_str2 = potential_color_str.split("\[0")[0]
+                    color_str2 = potential_color_str.split('\x1b[0')[0]
                     color_str = color_str1 if len(color_str1) < len(color_str2) else color_str2
 
                     if color_str:

--- a/parsers/tests/test_json2html.py
+++ b/parsers/tests/test_json2html.py
@@ -78,6 +78,39 @@ class Json2HtmlTests(unittest.TestCase):
         self.assertEqual(first.count('id="lines1"'), 1)
         self.assertNotIn('id="lines0"', first)
 
+    def test_top_level_infos_are_rendered(self):
+        """Main sections carry infos in real linpeas output (╚ reference links) and
+        must be rendered instead of being passed to parse_list as line objects."""
+        data = {
+            "Users Info": {
+                "sections": {},
+                "lines": [
+                    {
+                        "raw_text": "user1:x:1000:1000::/home/user1:/bin/bash",
+                        "clean_text": "user1:x:1000:1000::/home/user1:/bin/bash",
+                        "colors": {},
+                    }
+                ],
+                "infos": ["https://book.hacktricks.xyz/privilege-escalation?x=1&y=2"],
+            },
+        }
+        html = self._render(data)
+        self.assertIn("https://book.hacktricks.xyz/privilege-escalation?x=1&amp;y=2", html)
+        self.assertNotIn("https://book.hacktricks.xyz/privilege-escalation?x=1&y=2", html)
+
+    def test_infos_with_markup_are_escaped_everywhere(self):
+        data = {
+            "Users Info": {
+                "sections": {},
+                "lines": [],
+                "infos": ["run <script>alert(1)</script> now"],
+            },
+        }
+        html = self._render(data)
+        self.assertIn("&lt;script&gt;alert(1)&lt;/script&gt;", html)
+        self.assertNotIn("<script>alert(1)</script>", html)
+
+
     def test_divs_are_balanced(self):
         html = self._render(SAMPLE_JSON)
         self.assertEqual(html.count("<div"), html.count("</div>"))

--- a/parsers/tests/test_json2pdf.py
+++ b/parsers/tests/test_json2pdf.py
@@ -1,0 +1,43 @@
+import unittest
+
+try:
+    from reportlab.platypus import Paragraph
+
+    from parsers import json2pdf
+
+    HAS_REPORTLAB = True
+except ImportError:  # pragma: no cover - depends on the environment
+    HAS_REPORTLAB = False
+
+
+SECTION = {
+    "infos": ['see <tool> "settings" at https://book.hacktricks.xyz/x?y=1&z=2'],
+    "lines": [
+        {"raw_text": "a", "colors": {}, "clean_text": "line one"},
+        {"raw_text": "b", "colors": {}, "clean_text": "line two"},
+    ],
+    "sections": {},
+}
+
+
+@unittest.skipUnless(HAS_REPORTLAB, "reportlab is not installed")
+class Json2PdfTests(unittest.TestCase):
+    def test_info_words_are_escaped_before_reaching_the_paragraph(self):
+        elements = json2pdf.build_main_section(SECTION, "Escalation")
+        info_paragraphs = [e for e in elements if isinstance(e, Paragraph) and e.style.name == "Italic"]
+        self.assertEqual(len(info_paragraphs), 1)
+        markup = info_paragraphs[0].text
+        self.assertIn("&lt;tool&gt;", markup)
+        self.assertNotIn("<tool>", markup)
+        self.assertIn('href="https://book.hacktricks.xyz/x?y=1&amp;z=2"', markup)
+        self.assertNotIn('href="https://book.hacktricks.xyz/x?y=1&z=2"', markup)
+
+    def test_document_renders_hostile_infos_without_error(self):
+        from parsers.json2pdf import MyDocTemplate
+
+        doc = MyDocTemplate("/tmp/peas_test_hostile.pdf")
+        doc.build(json2pdf.build_main_section(SECTION, "Escalation"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/parsers/tests/test_peas2json.py
+++ b/parsers/tests/test_peas2json.py
@@ -1,0 +1,26 @@
+import unittest
+import warnings
+from pathlib import Path
+
+from parsers import peas2json
+
+
+class Peas2JsonTests(unittest.TestCase):
+    def test_module_compiles_without_syntax_warning(self):
+        source = Path(peas2json.__file__).read_text()
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            compile(source, str(peas2json.__file__), "exec")
+        syntax_warnings = [w for w in caught if issubclass(w.category, SyntaxWarning)]
+        self.assertEqual(syntax_warnings, [])
+
+    def test_get_colors_stops_at_color_and_reset_boundaries(self):
+        line = "\x1b[1;32muser\x1b[0m\x1b[1;31mroot\x1b[0m"
+        self.assertEqual(peas2json.get_colors(line), {"GREEN": ["user"], "RED": ["root"]})
+
+    def test_get_colors_of_plain_line_is_empty(self):
+        self.assertEqual(peas2json.get_colors("no colors in here"), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Rendering a HTML report from a real linpeas output currently crashes whenever a main section carries a `╚ ` info line (the usual reference links to book.hacktricks.xyz), because `parse_json` passes every list value of a top-level section straight into `parse_list` — which expects line objects with a `clean_text` key — while top-level `infos` are plain strings:

```
TypeError: string indices must be integers, not 'str'
```

Reproducer (fed through peas2json exactly like a real run):

```
══════════════╣ Users Info
╚ https://book.hacktricks.xyz/linux-hardening/privilege-escalation#users
user1:x:1000:1000::/home/user1:/bin/bash
```

The fix extracts the info rendering that `parse_dict` already had into a `parse_infos()` helper and uses it for the top level too, so those references now show up in the report instead of killing it.

While in the parsers I fixed two more things I hit on the way:

- **json2pdf**: info words were embedded into reportlab `Paragraph`s unescaped. reportlab parses that text as mini-HTML, so angle brackets, ampersands or quotes coming from the scanned machine broke the PDF or injected markup. The `clean_text` lines were already escaped — infos get the same treatment now.
- **peas2json**: `get_colors` split on the source literal `"\\[0"`, an invalid escape sequence that Python warns about on every run (`SyntaxWarning: invalid escape sequence '\\['`) and that never matches a real terminal reset. It now splits on the actual `ESC [0` sequence; behaviour is unchanged for normal terminal output.

Verified locally with the same suites CI runs: `python3 -m unittest discover -s parsers/tests` (13 tests) and `python3 -m unittest discover -s linPEAS/tests` (44 tests) both green, plus the end-to-end reproduction above rendering cleanly.