### PR TITLE
wordlist-updater: refresh linpeas vulnerability lists

### DIFF
--- a/linPEAS/builder/linpeas_parts/functions/kernel_cve_registry_checks.sh
+++ b/linPEAS/builder/linpeas_parts/functions/kernel_cve_registry_checks.sh
@@ -1,13 +1,13 @@
 # Title: Function - kernel_cve_registry_checks
 # ID: kernel_cve_registry_checks
 # Author: Carlos Polop
-# Last Update: 17-08-2026
+# Last Update: 05-09-2026
 # Description: Evaluate declared kernel CVE rules using kernel version, arch, kernel config, sysctl and command prerequisites.
-# Description: Data source chunks KERNEL_CVE_DATA_1..23 are capped to 25 rows each.
+# Description: Data source chunks KERNEL_CVE_DATA_1..24 are capped to 25 rows each.
 # License: GNU GPL
 # Version: 1.0
 # Functions Used: echo_not_found, print_3title, print_list
-# Global Variables: $E, $KERNEL_CVE_DATA_1, $KERNEL_CVE_DATA_2, $KERNEL_CVE_DATA_3, $KERNEL_CVE_DATA_4, $KERNEL_CVE_DATA_5, $KERNEL_CVE_DATA_6, $KERNEL_CVE_DATA_7, $KERNEL_CVE_DATA_8, $KERNEL_CVE_DATA_9, $KERNEL_CVE_DATA_10, $KERNEL_CVE_DATA_11, $KERNEL_CVE_DATA_12, $KERNEL_CVE_DATA_13, $KERNEL_CVE_DATA_14, $KERNEL_CVE_DATA_15, $KERNEL_CVE_DATA_16, $KERNEL_CVE_DATA_17, $KERNEL_CVE_DATA_18, $KERNEL_CVE_DATA_19, $KERNEL_CVE_DATA_20, $KERNEL_CVE_DATA_21, $KERNEL_CVE_DATA_22, $KERNEL_CVE_DATA_23, $SED_GREEN, $SED_RED_YELLOW
+# Global Variables: $E, $KERNEL_CVE_DATA_1, $KERNEL_CVE_DATA_2, $KERNEL_CVE_DATA_3, $KERNEL_CVE_DATA_4, $KERNEL_CVE_DATA_5, $KERNEL_CVE_DATA_6, $KERNEL_CVE_DATA_7, $KERNEL_CVE_DATA_8, $KERNEL_CVE_DATA_9, $KERNEL_CVE_DATA_10, $KERNEL_CVE_DATA_11, $KERNEL_CVE_DATA_12, $KERNEL_CVE_DATA_13, $KERNEL_CVE_DATA_14, $KERNEL_CVE_DATA_15, $KERNEL_CVE_DATA_16, $KERNEL_CVE_DATA_17, $KERNEL_CVE_DATA_18, $KERNEL_CVE_DATA_19, $KERNEL_CVE_DATA_20, $KERNEL_CVE_DATA_21, $KERNEL_CVE_DATA_22, $KERNEL_CVE_DATA_23, $KERNEL_CVE_DATA_24, $SED_GREEN, $SED_RED_YELLOW
 # Initial Functions: echo_not_found, print_3title, print_list
 # Generated Global Variables: $KERNEL_CVE_CFG_FILE, $KERNEL_CVE_CFG_SOURCE, $KERNEL_CVE_CFG_LINE, $KERNEL_CVE_CFG_KEY, $KERNEL_CVE_CFG_EXPR, $KERNEL_CVE_CFG_EXPECT, $KERNEL_CVE_CFG_OP, $KERNEL_CVE_CFG_CUR, $KERNEL_CVE_SYS_EXPR, $KERNEL_CVE_SYS_KEY, $KERNEL_CVE_SYS_OP, $KERNEL_CVE_SYS_VAL, $KERNEL_CVE_SYS_CUR, $KERNEL_CVE_REQS, $KERNEL_CVE_REQ, $KERNEL_CVE_REQ_LINES, $KERNEL_CVE_ID, $KERNEL_CVE_ID_NORM, $KERNEL_CVE_NAME, $KERNEL_CVE_TAGS, $KERNEL_CVE_RANK, $KERNEL_CVE_COMMENTS, $KERNEL_CVE_EXPL, $KERNEL_CVE_VERS, $KERNEL_CVE_VER_LINES, $KERNEL_CVE_ALT, $KERNEL_CVE_MIL, $KERNEL_CVE_TOKEN_OK, $KERNEL_CVE_MATCHES, $KERNEL_CVE_KERNEL_RELEASE, $KERNEL_CVE_KERNEL_VERSION, $KERNEL_CVE_KERNEL_ARCH, $KERNEL_CVE_KERNEL_OS, $KERNEL_CVE_VER, $KERNEL_CVE_OP, $KERNEL_CVE_REQVER, $KERNEL_CVE_CURVER, $KERNEL_CVE_CMP, $KERNEL_CVE_PRINT_ID, $KERNEL_CVE_PRINT_REASON, $KERNEL_CVE_ID_RAW, $KERNEL_CVE_ID_ITEM, $KERNEL_CVE_ID_OUT, $KERNEL_CVE_ALL_DATA, $KERNEL_CVE_PRINT_LINE
 # Fat linpeas: 0
@@ -257,17 +257,17 @@ kercve_run_registry() {
         fi
     done
 
-    KERNEL_CVE_ALL_DATA=$(printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s" \
+    KERNEL_CVE_ALL_DATA=$(printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s" \
         "$KERNEL_CVE_DATA_1" "$KERNEL_CVE_DATA_2" "$KERNEL_CVE_DATA_3" "$KERNEL_CVE_DATA_4" "$KERNEL_CVE_DATA_5" \
         "$KERNEL_CVE_DATA_6" "$KERNEL_CVE_DATA_7" "$KERNEL_CVE_DATA_8" "$KERNEL_CVE_DATA_9" "$KERNEL_CVE_DATA_10" \
         "$KERNEL_CVE_DATA_11" "$KERNEL_CVE_DATA_12" "$KERNEL_CVE_DATA_13" "$KERNEL_CVE_DATA_14" "$KERNEL_CVE_DATA_15" \
         "$KERNEL_CVE_DATA_16" "$KERNEL_CVE_DATA_17" "$KERNEL_CVE_DATA_18" "$KERNEL_CVE_DATA_19" "$KERNEL_CVE_DATA_20" \
-        "$KERNEL_CVE_DATA_21" "$KERNEL_CVE_DATA_22" "$KERNEL_CVE_DATA_23")
+        "$KERNEL_CVE_DATA_21" "$KERNEL_CVE_DATA_22" "$KERNEL_CVE_DATA_23" "$KERNEL_CVE_DATA_24")
 
     print_list "Operating system ............. $KERNEL_CVE_KERNEL_OS\n"
     print_list "Kernel release ............... $KERNEL_CVE_KERNEL_RELEASE\n"
     print_list "Comparable version ........... $KERNEL_CVE_KERNEL_VERSION\n"
-    print_list "Data chunk limit ............. max 25 rows per KERNEL_CVE_DATA_* variable (1..23)\n"
+    print_list "Data chunk limit ............. max 25 rows per KERNEL_CVE_DATA_* variable (1..24)\n"
     if [ -n "$KERNEL_CVE_CFG_SOURCE" ]; then
         print_list "Kernel config source ......... $KERNEL_CVE_CFG_SOURCE\n"
     else

--- a/linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh
+++ b/linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh
@@ -2,14 +2,14 @@
 # ID: kernel_cve_registry_data
 # Author: Carlos Polop
 # Contributor: Arjay Saguisa
-# Last Update: 17-08-2026
+# Last Update: 05-09-2026
 # Description: Embedded kernel exploit matching datasets extracted from linux-exploit-suggester and linux-exploit-suggester-2 examples. Data is split across KERNEL_CVE_DATA_1..X with a maximum of 25 rows per env variable. This file also stores reference-only CVE tokens found in example repos when no explicit suggester matching rule exists.
 # License: GNU GPL
 # Version: 1.0
 # Functions Used:
 # Global Variables:
 # Initial Functions:
-# Generated Global Variables: $KERNEL_CVE_DATA_1, $KERNEL_CVE_DATA_2, $KERNEL_CVE_DATA_3, $KERNEL_CVE_DATA_4, $KERNEL_CVE_DATA_5, $KERNEL_CVE_DATA_6, $KERNEL_CVE_DATA_7, $KERNEL_CVE_DATA_8, $KERNEL_CVE_DATA_9, $KERNEL_CVE_DATA_10, $KERNEL_CVE_DATA_11, $KERNEL_CVE_DATA_12, $KERNEL_CVE_DATA_13, $KERNEL_CVE_DATA_14, $KERNEL_CVE_DATA_15, $KERNEL_CVE_DATA_16, $KERNEL_CVE_DATA_17, $KERNEL_CVE_DATA_18, $KERNEL_CVE_DATA_19, $KERNEL_CVE_DATA_20, $KERNEL_CVE_DATA_21, $KERNEL_CVE_DATA_22, $KERNEL_CVE_DATA_23
+# Generated Global Variables: $KERNEL_CVE_DATA_1, $KERNEL_CVE_DATA_2, $KERNEL_CVE_DATA_3, $KERNEL_CVE_DATA_4, $KERNEL_CVE_DATA_5, $KERNEL_CVE_DATA_6, $KERNEL_CVE_DATA_7, $KERNEL_CVE_DATA_8, $KERNEL_CVE_DATA_9, $KERNEL_CVE_DATA_10, $KERNEL_CVE_DATA_11, $KERNEL_CVE_DATA_12, $KERNEL_CVE_DATA_13, $KERNEL_CVE_DATA_14, $KERNEL_CVE_DATA_15, $KERNEL_CVE_DATA_16, $KERNEL_CVE_DATA_17, $KERNEL_CVE_DATA_18, $KERNEL_CVE_DATA_19, $KERNEL_CVE_DATA_20, $KERNEL_CVE_DATA_21, $KERNEL_CVE_DATA_22, $KERNEL_CVE_DATA_23, $KERNEL_CVE_DATA_24
 # Fat linpeas: 0
 # Small linpeas: 1
 
@@ -673,4 +673,30 @@ CVE-2026-64600	RefluXFS stale mapping race	pkg=linux-kernel,ver>=6.13,ver<6.18.3
 CVE-2026-64600	RefluXFS stale mapping race	pkg=linux-kernel,ver>=6.19,ver<7.1.4,CONFIG_XFS_FS=[my],cmd:grep -qw xfs /proc/mounts		1	Fixed in stable 7.1.4; requires an XFS filesystem with reflink enabled
 CVE-2026-64600	RefluXFS stale mapping race	pkg=linux-kernel,ver>=7.2,ver<7.3,CONFIG_XFS_FS=[my],cmd:uname -r 2>/dev/null | grep -Eq '^7\.2\.0-rc[123]([-.]|$)',cmd:grep -qw xfs /proc/mounts		1	Fixed in mainline 7.2-rc4; requires an XFS filesystem with reflink enabled
 EOF_DATA_23
+)"
+
+KERNEL_CVE_DATA_24="$(cat <<'EOF_DATA_24'
+CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=5.15.180,ver<5.15.212,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tFixed in stable 5.15.212; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=6.1.132,ver<6.1.178,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tFixed in stable 6.1.178; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=6.6.84,ver<6.6.145,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tFixed in stable 6.6.145; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=6.12.20,ver<6.12.97,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tFixed in stable 6.12.97; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=6.13.8,ver<6.14,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tAffected stable 6.13 range; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=6.14,ver<6.18.40,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tFixed in stable 6.18.40; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=6.19,ver<7.1.5,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tFixed in stable 7.1.5 and mainline 7.2; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=2.6.25,ver<5.10.265,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 5.10.265; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=5.11,ver<5.15.216,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 5.15.216; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=5.16,ver<6.1.183,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 6.1.183; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=6.2,ver<6.6.148,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 6.6.148; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=6.7,ver<6.12.101,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 6.12.101; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=6.13,ver<6.18.42,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 6.18.42; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=6.19,ver<7.1.6,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 7.1.6 and mainline 7.2; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-53365\tVsockDrop virtio-vsock zerocopy refcount flaw\tpkg=linux-kernel,ver>=6.7,ver<6.12.97,CONFIG_VSOCKETS=[my],CONFIG_VIRTIO_VSOCKETS=[my],CONFIG_IO_URING=y\t\t1\tFixed in stable 6.12.97; public exploit uses io_uring and AF_VSOCK
+CVE-2026-53365\tVsockDrop virtio-vsock zerocopy refcount flaw\tpkg=linux-kernel,ver>=6.13,ver<6.18.34,CONFIG_VSOCKETS=[my],CONFIG_VIRTIO_VSOCKETS=[my],CONFIG_IO_URING=y\t\t1\tFixed in stable 6.18.34; public exploit uses io_uring and AF_VSOCK
+CVE-2026-53365\tVsockDrop virtio-vsock zerocopy refcount flaw\tpkg=linux-kernel,ver>=6.19,ver<7.0.11,CONFIG_VSOCKETS=[my],CONFIG_VIRTIO_VSOCKETS=[my],CONFIG_IO_URING=y\t\t1\tFixed in stable 7.0.11 and mainline 7.1; public exploit uses io_uring and AF_VSOCK
+CVE-2026-53361\tBadGarbage AF_UNIX garbage-collector race\tpkg=linux-kernel,ver>=6.1.141,ver<6.1.183\t\t1\tFixed in stable 6.1.183; public exploit can provide local root and container escape
+CVE-2026-53361\tBadGarbage AF_UNIX garbage-collector race\tpkg=linux-kernel,ver>=6.6.93,ver<6.6.144\t\t1\tFixed in stable 6.6.144; public exploit can provide local root and container escape
+CVE-2026-53361\tBadGarbage AF_UNIX garbage-collector race\tpkg=linux-kernel,ver>=6.9,ver<6.12.95\t\t1\tFixed in stable 6.12.95; public exploit can provide local root and container escape
+CVE-2026-53361\tBadGarbage AF_UNIX garbage-collector race\tpkg=linux-kernel,ver>=6.13,ver<6.18.38\t\t1\tFixed in stable 6.18.38; public exploit can provide local root and container escape
+CVE-2026-53361\tBadGarbage AF_UNIX garbage-collector race\tpkg=linux-kernel,ver>=6.19,ver<7.1\t\t1\tFixed in mainline 7.1; public exploit can provide local root and container escape
+EOF_DATA_24
 )"

--- a/linPEAS/builder/linpeas_parts/variables/sidB.sh
+++ b/linPEAS/builder/linpeas_parts/variables/sidB.sh
@@ -1,7 +1,7 @@
 # Title: Variables - sidB
 # ID: sidB
 # Author: Carlos Polop
-# Last Update: 06-07-2026
+# Last Update: 05-09-2026
 # Description: Dangerous sid binaries
 # License: GNU GPL
 # Version: 1.0
@@ -38,7 +38,7 @@ sidB="/apache2$%Read_root_passwd__apache2_-f_/etc/shadow\(CVE-2019-0211\)\
  /lpc$%S.u.S.E_Linux_5.2\
  /lpr$%BSD/OS2.1/FreeBSD2.1.5/NeXTstep4.x/IRIX6.4/SunOS4.1.3/4.1.4\(09-1996\)\
  /mail.local$%NetBSD_7.0-7.0.1__6.1-6.1.5__6.0-6.0.6\
- /mount$%Apple_Mac_OSX\(Lion\)_Kernel_xnu-1699.32.7_except_xnu-1699.24.8\
+ /mount$%Apple_Mac_OSX\(Lion\)_Kernel_xnu-1699.32.7_except_xnu-1699.24.8/util-linux_mount<=2.41.3\(CVE-2026-27456\)/util-linux_mount>=2.39_before_2.41.5_or_2.42.2\(CVE-2026-53612\)/util-linux_mount>=2.39.1_before_2.41.5_or_2.42.2\(CVE-2026-53614\)/util-linux_mount_2.39_to_2.41.5_or_2.42_to_2.42.2\(CVE-2026-76642\)/util-linux_mount_2.42.x_before_2.42.3\(CVE-2026-78409\)/util-linux_mount<=2.42.2\(CVE-2026-78410\)\
  /movemail$%Emacs\(08-1986\)\
  /mrinfo$%NetBSD_Sep_17_2002_https://securitytracker.com/id/1005234\
  /mtrace$%NetBSD_Sep_17_2002_https://securitytracker.com/id/1005234\


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->\n<!-- daily-stats-summary: Refreshed LinPEAS vulnerability wordlists. -->\n\nAutomated LinPEAS vulnerability wordlist refresh.\n\nAgent summary:\nPEASS linpeas wordlist updater completed successfully with 49 steps. Agent Comment: Plan:
1. Locate the LinPEAS list sources, usage sites, repository instructions, and 30-day history.
2. Compare current entries with authoritative upstream advisories and trusted exploit registries.
3. Apply only high-confidence list-data changes, then inspect the diff.
4. Run the requested LinPEAS build and report exact outcomes.
Repository location and targets are confirmed, with a clean working tree. I’m now tracing their consumers and reviewing the 30-day history before assessing data freshness.
The initial combined inspection used shell brace expansion unsupported by the executor’s `/bin/sh`; no repository changes occurred. I’m rerunning it portably with explicit paths.
History review shows one intentional registry update on August 17 and recent prior updates to `sidB.sh` and `sudovB.sh`; I will preserve those changes. The registry is hand-maintained source data consumed by the generic matcher, while generated LinPEAS outputs are not being edited. Next I’m checking upstream deltas and official advisory boundaries.
The upstream exploit-suggester datasets have had no commits during the lookback, and no newer sudo release exists beyond the version already covered. I’m broadening the authoritative advisory check for any post-refresh local-privilege-escalation boundary suitable for this generic registry.
The high-confidence refresh set is now defined: four kernel issues with public privilege-escalation exploit material and official Linux CNA version ranges, plus newly published/updated upstream `mount(8)` SUID advisories. I’m applying these as one new registry chunk and one compact `sidB.sh` description update; `sudovB.sh` remains unchanged because its regex already covers the latest sudo advisory boundary.
The data edits are applied. I’m now validating structure, exact row counts, shell syntax, version-boundary behavior, and the focused diff before running the full builder.
Structural validation passed: 24 contiguous chunks, 22 rows in the new chunk (below the 25-row cap), all edited shell files parse, and `git diff --check` is clean. I’m running the exact requested builder command from the `linPEAS` module root.
The full LinPEAS build completed successfully and wrote `/tmp/linpeas_fat.sh`. I’m doing final artifact checks to confirm the new chunk and SUID advisory text are embedded, then I’ll verify the working tree contains only the intended source edits.
### Files updated
- `variables/sidB.sh`
  - Refreshed `/mount` with six util-linux SUID vulnerabilities: CVE-2026-27456, 53612, 53614, 76642, 78409, and 78410, using [official util-linux advisories](https://github.com/util-linux/util-linux/security/advisories).
- `variables/kernel_cve_registry_data.sh`
  - Added 22 version-specific rules for CVE-2026-64531, CVE-2026-64564, CVE-2026-53365, and CVE-2026-53361.
  - Boundaries were cross-checked against official Linux CNA records: [64531](https://cve.org/CVERecord/?id=CVE-2026-64531), [64564](https://cve.org/CVERecord/?id=CVE-2026-64564), [53365](https://cve.org/CVERecord/?id=CVE-2026-53365), [53361](https://cve.org/CVERecord/?id=CVE-2026-53361).
- `functions/kernel_cve_registry_checks.sh`
  - Extended registry aggregation from 23 to 24 data chunks.

### Build validation
- Requested build succeeded:
  - `python3 -m builder.linpeas_builder --all --output /tmp/linpeas_fat.sh`
- Generated `/tmp/linpeas_fat.sh` successfully.
- `bash -n`, shell syntax checks, chunk limits, and `git diff --check` all passed.

### Skipped
- `sudovB.sh`: unchanged; its regex already covers vulnerable releases through 1.9.17p2, which remains the latest [official sudo release](https://github.com/sudo-project/sudo/releases/tag/v1.9.17p2).
- No other static lists had reliable, non-duplicate updates.\n\nGenerated by PEASS wordlist updater workflow.