### PR TITLE
new-check(winpeas): add high-impact vulnerability detection

### DIFF
--- a/winPEAS/winPEASexe/Tests/WritableServiceDllTests.cs
+++ b/winPEAS/winPEASexe/Tests/WritableServiceDllTests.cs
@@ -1,0 +1,152 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using winPEAS.Info.ServicesInfo;
+
+namespace Tests
+{
+    [TestClass]
+    public class WritableServiceDllTests
+    {
+        private const string UsersSid = "S-1-5-32-545";
+
+        [TestMethod]
+        public void NormalizesServicePathsAndRequiresUnprotectedSystemSvchost()
+        {
+            Assert.AreEqual(
+                @"C:\Windows\System32\example.dll",
+                ServicesInfoHelper.NormalizeServiceDllPath(
+                    @" ""%SystemRoot%\System32\example.dll"" ",
+                    @"C:\Windows"));
+            Assert.AreEqual(
+                @"C:\Windows\System32\example.dll",
+                ServicesInfoHelper.NormalizeServiceDllPath(
+                    @"\??\C:\Windows\System32\example.dll",
+                    @"C:\Windows"));
+            Assert.AreEqual(
+                @"C:\Windows\Sysnative\example.dll",
+                ServicesInfoHelper.GetFileSystemAccessPath(
+                    @"C:\Windows\System32\example.dll",
+                    @"C:\Windows",
+                    true,
+                    false));
+
+            Assert.IsTrue(ServicesInfoHelper.IsEligibleSystemService(
+                0x20,
+                2,
+                0,
+                "LocalSystem",
+                @"""\SystemRoot\System32\svchost.exe"" -k netsvcs -p",
+                @"C:\Windows"));
+            Assert.IsFalse(ServicesInfoHelper.IsEligibleSystemService(
+                0x10,
+                2,
+                0,
+                "LocalSystem",
+                @"%SystemRoot%\System32\svchost.exe -k netsvcs -p",
+                @"C:\Windows"));
+            Assert.IsFalse(ServicesInfoHelper.IsEligibleSystemService(
+                0x20,
+                4,
+                0,
+                "LocalSystem",
+                @"%SystemRoot%\System32\svchost.exe -k netsvcs -p",
+                @"C:\Windows"));
+            Assert.IsFalse(ServicesInfoHelper.IsEligibleSystemService(
+                0x20,
+                2,
+                2,
+                "LocalSystem",
+                @"%SystemRoot%\System32\svchost.exe -k netsvcs -p",
+                @"C:\Windows"));
+            Assert.IsFalse(ServicesInfoHelper.IsEligibleSystemService(
+                0x20,
+                2,
+                0,
+                @"NT AUTHORITY\LocalService",
+                @"%SystemRoot%\System32\svchost.exe -k LocalService",
+                @"C:\Windows"));
+            Assert.IsFalse(ServicesInfoHelper.IsEligibleSystemService(
+                0x20,
+                2,
+                0,
+                "LocalSystem",
+                @"C:\Users\Public\svchost.exe -k fake",
+                @"C:\Windows"));
+        }
+
+        [TestMethod]
+        public void EffectiveAccessHonorsDenyAceOrder()
+        {
+            var tokenSids = new HashSet<string> { UsersSid };
+            RawSecurityDescriptor allowed = CreateDescriptor(
+                new AceQualifier[] { AceQualifier.AccessAllowed },
+                new int[] { 0x00000002 });
+            Assert.IsTrue(ServicesInfoHelper.HasEffectiveAccess(allowed, tokenSids, 0x00000002));
+            Assert.IsFalse(ServicesInfoHelper.HasEffectiveAccess(allowed, tokenSids, 0x00010000));
+
+            RawSecurityDescriptor deniedThenAllowed = CreateDescriptor(
+                new AceQualifier[] { AceQualifier.AccessDenied, AceQualifier.AccessAllowed },
+                new int[] { 0x00000002, 0x10000000 });
+            Assert.IsFalse(ServicesInfoHelper.HasEffectiveAccess(deniedThenAllowed, tokenSids, 0x00000002));
+            Assert.IsTrue(ServicesInfoHelper.HasEffectiveAccess(deniedThenAllowed, tokenSids, 0x00010000));
+        }
+
+        [TestMethod]
+        public void RequiresConcretePlantOrReplacementRights()
+        {
+            var tokenSids = new HashSet<string> { UsersSid };
+            RawSecurityDescriptor readOnlyFile = CreateDescriptor(
+                new AceQualifier[] { AceQualifier.AccessAllowed },
+                new int[] { 0x00000001 });
+            RawSecurityDescriptor createOnlyDirectory = CreateDescriptor(
+                new AceQualifier[] { AceQualifier.AccessAllowed },
+                new int[] { 0x00000002 });
+            RawSecurityDescriptor replaceDirectory = CreateDescriptor(
+                new AceQualifier[] { AceQualifier.AccessAllowed },
+                new int[] { 0x00000042 });
+
+            Assert.IsFalse(string.IsNullOrEmpty(ServicesInfoHelper.GetReplacementReason(
+                null,
+                createOnlyDirectory,
+                false,
+                tokenSids)));
+            Assert.AreEqual(string.Empty, ServicesInfoHelper.GetReplacementReason(
+                readOnlyFile,
+                createOnlyDirectory,
+                true,
+                tokenSids));
+            Assert.IsFalse(string.IsNullOrEmpty(ServicesInfoHelper.GetReplacementReason(
+                readOnlyFile,
+                replaceDirectory,
+                true,
+                tokenSids)));
+        }
+
+        private static RawSecurityDescriptor CreateDescriptor(
+            AceQualifier[] qualifiers,
+            int[] accessMasks)
+        {
+            var dacl = new RawAcl(2, qualifiers.Length);
+            var users = new SecurityIdentifier(UsersSid);
+            for (int index = 0; index < qualifiers.Length; index++)
+            {
+                dacl.InsertAce(index, new CommonAce(
+                    AceFlags.None,
+                    qualifiers[index],
+                    accessMasks[index],
+                    users,
+                    false,
+                    null));
+            }
+
+            return new RawSecurityDescriptor(
+                ControlFlags.DiscretionaryAclPresent,
+                null,
+                null,
+                null,
+                dacl);
+        }
+    }
+}

--- a/winPEAS/winPEASexe/Tests/winPEAS.Tests.csproj
+++ b/winPEAS/winPEASexe/Tests/winPEAS.Tests.csproj
@@ -103,6 +103,7 @@
     <Compile Include="SccmNetworkAccessAccountTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SmokeTests.cs" />
+    <Compile Include="WritableServiceDllTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/winPEAS/winPEASexe/winPEAS/Checks/ServicesInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/ServicesInfo.cs
@@ -12,11 +12,11 @@ namespace winPEAS.Checks
     {
         Dictionary<string, string> modifiableServices = new Dictionary<string, string>();
 
-        public string[] MitreAttackIds { get; } = new[] { "T1007", "T1543.003", "T1574.001", "T1574.011", "T1014", "T1068" };
+        public string[] MitreAttackIds { get; } = new[] { "T1007", "T1543.003", "T1574.001", "T1574.010", "T1574.011", "T1014", "T1068" };
 
         public void PrintInfo(bool isDebug)
         {
-            Beaprint.GreatPrint("Services Information", "T1007,T1543.003,T1574.001,T1574.011,T1014,T1068");
+            Beaprint.GreatPrint("Services Information", "T1007,T1543.003,T1574.001,T1574.010,T1574.011,T1014,T1068");
 
             /// Start finding Modifiable services so any function could use them
 
@@ -37,6 +37,7 @@ namespace winPEAS.Checks
                 PrintInterestingServices,
                 PrintModifiableServices,
                 PrintWritableRegServices,
+                PrintWritableSystemServiceDlls,
                 PrintPathDllHijacking,
                 PrintOemPrivilegedUtilities,
                 PrintLegacySignedKernelDrivers,
@@ -180,6 +181,45 @@ namespace winPEAS.Checks
                     foreach (Dictionary<string, string> writeServReg in regPerms)
                         Beaprint.AnsiPrint(string.Format("    {0} ({1})", writeServReg["Path"], writeServReg["Permissions"]), colorsWR);
 
+                }
+            }
+            catch (Exception ex)
+            {
+                Beaprint.PrintException(ex.Message);
+            }
+        }
+
+        void PrintWritableSystemServiceDlls()
+        {
+            try
+            {
+                Beaprint.MainPrint("Writable DLLs loaded by LocalSystem services", "T1574.010");
+                Beaprint.LinkPrint(
+                    "https://attack.mitre.org/techniques/T1574/010/",
+                    "A replaceable DLL loaded by an enabled LocalSystem service can execute as SYSTEM when the service starts.");
+
+                WritableServiceDllReport report = ServicesInfoHelper.GetWritableSystemServiceDlls(Checks.CurrentUserSiDs);
+                if (report.Findings.Count == 0)
+                {
+                    Beaprint.GoodPrint($"    No replaceable ServiceDll paths found in {report.ServicesInspected} inspected service(s).");
+                }
+
+                foreach (WritableServiceDllInfo finding in report.Findings)
+                {
+                    Beaprint.BadPrint($"    {finding.ServiceName} ({finding.Account})");
+                    Beaprint.NoColorPrint($"      ServiceDll : {finding.ServiceDllPath}");
+                    Beaprint.NoColorPrint($"      DLL exists : {finding.FileExists}");
+                    Beaprint.BadPrint($"      Evidence    : {finding.AccessReason}");
+                    Beaprint.PrintLineSeparator();
+                }
+
+                if (report.ServiceLimitReached)
+                {
+                    Beaprint.GrayPrint($"    Service inspection stopped at the safety limit of {ServicesInfoHelper.MaxServiceDllServices}.");
+                }
+                if (report.FindingLimitReached)
+                {
+                    Beaprint.GrayPrint($"    Findings were capped at {ServicesInfoHelper.MaxServiceDllFindings}.");
                 }
             }
             catch (Exception ex)

--- a/winPEAS/winPEASexe/winPEAS/Info/ServicesInfo/ServicesInfoHelper.cs
+++ b/winPEAS/winPEASexe/winPEAS/Info/ServicesInfo/ServicesInfoHelper.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
 using System.ServiceProcess;
 using System.Text.RegularExpressions;
 using winPEAS.Helpers;
@@ -18,8 +19,46 @@ using winPEAS.Native;
 
 namespace winPEAS.Info.ServicesInfo
 {
+    internal sealed class WritableServiceDllInfo
+    {
+        public string ServiceName { get; set; }
+        public string Account { get; set; }
+        public string ServiceDllPath { get; set; }
+        public bool FileExists { get; set; }
+        public string AccessReason { get; set; }
+    }
+
+    internal sealed class WritableServiceDllReport
+    {
+        public List<WritableServiceDllInfo> Findings { get; } = new List<WritableServiceDllInfo>();
+        public int ServicesInspected { get; set; }
+        public bool ServiceLimitReached { get; set; }
+        public bool FindingLimitReached { get; set; }
+    }
+
     class ServicesInfoHelper
     {
+        internal const int MaxServiceDllServices = 4096;
+        internal const int MaxServiceDllFindings = 64;
+
+        private const int ServiceWin32ShareProcess = 0x20;
+        private const int ServiceWin32TypeMask = 0x30;
+        private const int ServiceDisabled = 0x4;
+        private const int FileWriteData = 0x00000002;
+        private const int FileAddFile = 0x00000002;
+        private const int FileDeleteChild = 0x00000040;
+        private const int Delete = 0x00010000;
+        private const int WriteDac = 0x00040000;
+        private const int WriteOwner = 0x00080000;
+        private const int FileAllAccess = 0x001F01FF;
+        private const int FileGenericRead = 0x00120089;
+        private const int FileGenericWrite = 0x00120116;
+        private const int FileGenericExecute = 0x001200A0;
+        private const int GenericAll = 0x10000000;
+        private const int GenericExecute = 0x20000000;
+        private const int GenericWrite = 0x40000000;
+        private const int GenericRead = unchecked((int)0x80000000);
+
         ///////////////////////////////////////////////
         //// Non Standard Services (Non Microsoft) ////
         ///////////////////////////////////////////////
@@ -379,6 +418,518 @@ namespace winPEAS.Info.ServicesInfo
             public DateTime? NotAfter { get; set; }
             public bool IsLegacyExpired { get; set; }
             public string Error { get; set; }
+        }
+
+
+        //////////////////////////////////////////////////////
+        //////// Writable LocalSystem service DLLs ///////////
+        //////////////////////////////////////////////////////
+        public static WritableServiceDllReport GetWritableSystemServiceDlls(Dictionary<string, string> currentUserSids)
+        {
+            var report = new WritableServiceDllReport();
+            if (currentUserSids == null || currentUserSids.Count == 0)
+            {
+                return report;
+            }
+
+            string windowsDirectory = Environment.GetEnvironmentVariable("SystemRoot");
+            if (string.IsNullOrWhiteSpace(windowsDirectory))
+            {
+                windowsDirectory = Environment.GetEnvironmentVariable("windir");
+            }
+            if (string.IsNullOrWhiteSpace(windowsDirectory))
+            {
+                return report;
+            }
+
+            var tokenSids = new HashSet<string>(currentUserSids.Keys, StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                using (RegistryKey servicesKey = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Services"))
+                {
+                    if (servicesKey == null)
+                    {
+                        return report;
+                    }
+
+                    string[] serviceNames = servicesKey.GetSubKeyNames();
+                    foreach (string serviceName in serviceNames)
+                    {
+                        if (report.ServicesInspected >= MaxServiceDllServices)
+                        {
+                            report.ServiceLimitReached = true;
+                            break;
+                        }
+                        if (report.Findings.Count >= MaxServiceDllFindings)
+                        {
+                            report.FindingLimitReached = true;
+                            break;
+                        }
+
+                        report.ServicesInspected++;
+                        try
+                        {
+                            using (RegistryKey serviceKey = servicesKey.OpenSubKey(serviceName))
+                            {
+                                if (serviceKey == null || !IsEligibleSystemService(
+                                    GetRegistryInt(serviceKey, "Type"),
+                                    GetRegistryInt(serviceKey, "Start"),
+                                    GetRegistryInt(serviceKey, "LaunchProtected"),
+                                    GetRegistryString(serviceKey, "ObjectName"),
+                                    GetRegistryString(serviceKey, "ImagePath"),
+                                    windowsDirectory))
+                                {
+                                    continue;
+                                }
+
+                                string rawServiceDll;
+                                if (!TryGetServiceDll(serviceKey, out rawServiceDll))
+                                {
+                                    continue;
+                                }
+
+                                string serviceDllPath = NormalizeServiceDllPath(rawServiceDll, windowsDirectory);
+                                if (string.IsNullOrWhiteSpace(serviceDllPath) || serviceDllPath.Length > 32767 ||
+                                    serviceDllPath.IndexOf('%') >= 0 || !IsLocalDrivePath(serviceDllPath))
+                                {
+                                    continue;
+                                }
+
+                                string accessPath = GetFileSystemAccessPath(
+                                    serviceDllPath,
+                                    windowsDirectory,
+                                    Environment.Is64BitOperatingSystem,
+                                    Environment.Is64BitProcess);
+                                bool fileExists = File.Exists(accessPath);
+                                string directoryPath = Path.GetDirectoryName(accessPath);
+                                if (string.IsNullOrWhiteSpace(directoryPath) || !Directory.Exists(directoryPath))
+                                {
+                                    continue;
+                                }
+
+                                RawSecurityDescriptor fileSecurity = fileExists
+                                    ? GetSecurityDescriptor(accessPath, false)
+                                    : null;
+                                RawSecurityDescriptor directorySecurity = GetSecurityDescriptor(directoryPath, true);
+                                string accessReason = GetReplacementReason(
+                                    fileSecurity,
+                                    directorySecurity,
+                                    fileExists,
+                                    tokenSids);
+                                if (string.IsNullOrEmpty(accessReason))
+                                {
+                                    continue;
+                                }
+
+                                report.Findings.Add(new WritableServiceDllInfo
+                                {
+                                    ServiceName = serviceName,
+                                    Account = GetDisplayAccount(GetRegistryString(serviceKey, "ObjectName")),
+                                    ServiceDllPath = serviceDllPath,
+                                    FileExists = fileExists,
+                                    AccessReason = accessReason,
+                                });
+                            }
+                        }
+                        catch
+                        {
+                            // A malformed or inaccessible service entry must not stop enumeration.
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Service registry enumeration can be restricted; keep this passive check quiet.
+            }
+
+            return report;
+        }
+
+        internal static bool IsEligibleSystemService(
+            int? serviceType,
+            int? startType,
+            int? launchProtected,
+            string account,
+            string imagePath,
+            string windowsDirectory)
+        {
+            return serviceType.HasValue && startType.HasValue &&
+                   (serviceType.Value & ServiceWin32TypeMask) == ServiceWin32ShareProcess &&
+                   startType.Value != ServiceDisabled &&
+                   (!launchProtected.HasValue || launchProtected.Value == 0) &&
+                   IsLocalSystemAccount(account) &&
+                   IsSystemSvchostImage(imagePath, windowsDirectory);
+        }
+
+        internal static bool IsLocalSystemAccount(string account)
+        {
+            if (string.IsNullOrWhiteSpace(account))
+            {
+                return true;
+            }
+
+            string normalized = account.Trim();
+            return normalized.Equals("LocalSystem", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals("SYSTEM", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals(@"NT AUTHORITY\SYSTEM", StringComparison.OrdinalIgnoreCase) ||
+                   normalized.Equals(@"NT AUTHORITY\LocalSystem", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static bool IsSystemSvchostImage(string rawImagePath, string windowsDirectory)
+        {
+            if (string.IsNullOrWhiteSpace(rawImagePath) || string.IsNullOrWhiteSpace(windowsDirectory))
+            {
+                return false;
+            }
+
+            string imagePath = rawImagePath.Trim();
+            string executable;
+            if (imagePath.StartsWith("\"", StringComparison.Ordinal))
+            {
+                int closingQuote = imagePath.IndexOf('"', 1);
+                if (closingQuote < 0)
+                {
+                    return false;
+                }
+                executable = imagePath.Substring(1, closingQuote - 1);
+            }
+            else
+            {
+                int extension = imagePath.IndexOf(".exe", StringComparison.OrdinalIgnoreCase);
+                if (extension < 0)
+                {
+                    return false;
+                }
+                executable = imagePath.Substring(0, extension + 4).Trim();
+            }
+
+            executable = StripWin32DevicePrefix(executable);
+            executable = ExpandWindowsPath(executable, windowsDirectory);
+            executable = StripWin32DevicePrefix(executable).Replace('/', '\\');
+            string windowsRoot = windowsDirectory.TrimEnd('\\', '/');
+            return executable.Equals(windowsRoot + @"\System32\svchost.exe", StringComparison.OrdinalIgnoreCase) ||
+                   executable.Equals(windowsRoot + @"\SysWOW64\svchost.exe", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal static string NormalizeServiceDllPath(string rawPath, string windowsDirectory)
+        {
+            if (string.IsNullOrWhiteSpace(rawPath))
+            {
+                return string.Empty;
+            }
+
+            string path = rawPath.Trim();
+            if (path.Length >= 2 && path[0] == '"' && path[path.Length - 1] == '"')
+            {
+                path = path.Substring(1, path.Length - 2).Trim();
+            }
+
+            path = StripWin32DevicePrefix(path);
+            path = ExpandWindowsPath(path, windowsDirectory);
+            path = StripWin32DevicePrefix(path);
+            return path.Trim().Replace('/', '\\');
+        }
+
+        internal static string GetFileSystemAccessPath(
+            string path,
+            string windowsDirectory,
+            bool is64BitOperatingSystem,
+            bool is64BitProcess)
+        {
+            if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(windowsDirectory) ||
+                !is64BitOperatingSystem || is64BitProcess)
+            {
+                return path;
+            }
+
+            string windowsRoot = windowsDirectory.TrimEnd('\\', '/');
+            string system32Prefix = windowsRoot + @"\System32\";
+            if (!path.StartsWith(system32Prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return path;
+            }
+
+            return windowsRoot + @"\Sysnative\" + path.Substring(system32Prefix.Length);
+        }
+
+        internal static string GetReplacementReason(
+            RawSecurityDescriptor fileSecurity,
+            RawSecurityDescriptor directorySecurity,
+            bool fileExists,
+            ISet<string> tokenSids)
+        {
+            if (directorySecurity == null || tokenSids == null || tokenSids.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            bool canControlDirectory = HasEffectiveAccess(directorySecurity, tokenSids, WriteDac) ||
+                                       HasEffectiveAccess(directorySecurity, tokenSids, WriteOwner);
+            if (!fileExists)
+            {
+                if (HasEffectiveAccess(directorySecurity, tokenSids, FileAddFile))
+                {
+                    return "FILE_ADD_FILE on the parent directory can plant the missing service DLL";
+                }
+                if (canControlDirectory)
+                {
+                    return "WRITE_DAC or WRITE_OWNER on the parent directory can grant DLL creation rights";
+                }
+                return string.Empty;
+            }
+
+            if (fileSecurity != null && HasEffectiveAccess(fileSecurity, tokenSids, FileWriteData))
+            {
+                return "FILE_WRITE_DATA is granted on the configured service DLL";
+            }
+            if (fileSecurity != null &&
+                (HasEffectiveAccess(fileSecurity, tokenSids, WriteDac) ||
+                 HasEffectiveAccess(fileSecurity, tokenSids, WriteOwner)))
+            {
+                return "WRITE_DAC or WRITE_OWNER on the service DLL can grant overwrite rights";
+            }
+            if (canControlDirectory)
+            {
+                return "WRITE_DAC or WRITE_OWNER on the parent directory can grant replacement rights";
+            }
+
+            bool canCreate = HasEffectiveAccess(directorySecurity, tokenSids, FileAddFile);
+            if (canCreate && HasEffectiveAccess(directorySecurity, tokenSids, FileDeleteChild))
+            {
+                return "FILE_ADD_FILE and FILE_DELETE_CHILD on the parent directory permit DLL replacement";
+            }
+            if (canCreate && fileSecurity != null && HasEffectiveAccess(fileSecurity, tokenSids, Delete))
+            {
+                return "DELETE on the DLL plus FILE_ADD_FILE on its parent permit DLL replacement";
+            }
+
+            return string.Empty;
+        }
+
+        internal static bool HasEffectiveAccess(
+            RawSecurityDescriptor security,
+            ISet<string> tokenSids,
+            int desiredAccess)
+        {
+            if (security == null || tokenSids == null || tokenSids.Count == 0 || desiredAccess == 0)
+            {
+                return false;
+            }
+
+            RawAcl dacl = security.DiscretionaryAcl;
+            if (dacl == null)
+            {
+                return true;
+            }
+
+            int remaining = desiredAccess;
+            foreach (GenericAce genericAce in dacl)
+            {
+                CommonAce ace = genericAce as CommonAce;
+                if (ace == null || ace.IsCallback ||
+                    (ace.AceFlags & AceFlags.InheritOnly) == AceFlags.InheritOnly ||
+                    !tokenSids.Contains(ace.SecurityIdentifier.Value))
+                {
+                    continue;
+                }
+
+                int accessMask = MapGenericFileRights(ace.AccessMask);
+                if (ace.AceQualifier == AceQualifier.AccessDenied && (accessMask & remaining) != 0)
+                {
+                    return false;
+                }
+                if (ace.AceQualifier == AceQualifier.AccessAllowed)
+                {
+                    remaining &= ~accessMask;
+                    if (remaining == 0)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static int MapGenericFileRights(int accessMask)
+        {
+            int mapped = accessMask;
+            if ((mapped & GenericAll) != 0)
+            {
+                mapped |= FileAllAccess;
+            }
+            if ((mapped & GenericRead) != 0)
+            {
+                mapped |= FileGenericRead;
+            }
+            if ((mapped & GenericWrite) != 0)
+            {
+                mapped |= FileGenericWrite;
+            }
+            if ((mapped & GenericExecute) != 0)
+            {
+                mapped |= FileGenericExecute;
+            }
+            return mapped & ~(GenericAll | GenericRead | GenericWrite | GenericExecute);
+        }
+
+        private static bool TryGetServiceDll(RegistryKey serviceKey, out string rawServiceDll)
+        {
+            rawServiceDll = string.Empty;
+            RegistryKey parametersKey = null;
+            try
+            {
+                parametersKey = serviceKey.OpenSubKey("Parameters");
+                RegistryKey sourceKey = parametersKey ?? serviceKey;
+
+                object manifest = sourceKey.GetValue(
+                    "ServiceManifest",
+                    null,
+                    RegistryValueOptions.DoNotExpandEnvironmentNames);
+                if (manifest != null && !string.IsNullOrWhiteSpace(manifest.ToString()))
+                {
+                    // A valid ServiceManifest can redirect the DLL independently of ServiceDll.
+                    return false;
+                }
+
+                RegistryValueKind kind = sourceKey.GetValueKind("ServiceDll");
+                if (kind != RegistryValueKind.ExpandString)
+                {
+                    return false;
+                }
+
+                object value = sourceKey.GetValue(
+                    "ServiceDll",
+                    null,
+                    RegistryValueOptions.DoNotExpandEnvironmentNames);
+                rawServiceDll = value == null ? string.Empty : value.ToString();
+                return !string.IsNullOrWhiteSpace(rawServiceDll);
+            }
+            catch
+            {
+                return false;
+            }
+            finally
+            {
+                parametersKey?.Dispose();
+            }
+        }
+
+        private static int? GetRegistryInt(RegistryKey key, string valueName)
+        {
+            try
+            {
+                object value = key.GetValue(valueName, null, RegistryValueOptions.DoNotExpandEnvironmentNames);
+                return value == null ? (int?)null : Convert.ToInt32(value);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string GetRegistryString(RegistryKey key, string valueName)
+        {
+            try
+            {
+                object value = key.GetValue(valueName, null, RegistryValueOptions.DoNotExpandEnvironmentNames);
+                return value == null ? string.Empty : value.ToString();
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static string GetDisplayAccount(string account)
+        {
+            return string.IsNullOrWhiteSpace(account) ? "LocalSystem (default)" : account;
+        }
+
+        private static string ExpandWindowsPath(string path, string windowsDirectory)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return string.Empty;
+            }
+
+            string expanded = path.Trim();
+            if (!string.IsNullOrWhiteSpace(windowsDirectory))
+            {
+                expanded = ReplaceWindowsDirectoryPrefix(expanded, @"\SystemRoot", windowsDirectory);
+                expanded = ReplaceWindowsDirectoryPrefix(expanded, "%SystemRoot%", windowsDirectory);
+                expanded = ReplaceWindowsDirectoryPrefix(expanded, "%windir%", windowsDirectory);
+            }
+
+            try
+            {
+                expanded = Environment.ExpandEnvironmentVariables(expanded);
+            }
+            catch
+            {
+                return string.Empty;
+            }
+            return expanded;
+        }
+
+        private static string ReplaceWindowsDirectoryPrefix(string path, string prefix, string windowsDirectory)
+        {
+            if (!path.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+                (path.Length > prefix.Length && path[prefix.Length] != '\\' && path[prefix.Length] != '/'))
+            {
+                return path;
+            }
+            return windowsDirectory.TrimEnd('\\', '/') + path.Substring(prefix.Length);
+        }
+
+        private static string StripWin32DevicePrefix(string path)
+        {
+            if (path.StartsWith(@"\??\", StringComparison.Ordinal))
+            {
+                return path.Substring(4);
+            }
+            if (path.StartsWith(@"\\?\", StringComparison.Ordinal))
+            {
+                return path.Substring(4);
+            }
+            return path;
+        }
+
+        private static bool IsLocalDrivePath(string path)
+        {
+            // Avoid UNC or device paths so this passive check cannot intentionally contact a remote host.
+            if (path.Length < 3 || !char.IsLetter(path[0]) || path[1] != ':' ||
+                (path[2] != '\\' && path[2] != '/'))
+            {
+                return false;
+            }
+
+            try
+            {
+                DriveType driveType = new DriveInfo(path.Substring(0, 3)).DriveType;
+                return driveType == DriveType.Fixed || driveType == DriveType.Removable || driveType == DriveType.Ram;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static RawSecurityDescriptor GetSecurityDescriptor(string path, bool isDirectory)
+        {
+            try
+            {
+                byte[] descriptor = isDirectory
+                    ? Directory.GetAccessControl(path, AccessControlSections.Access).GetSecurityDescriptorBinaryForm()
+                    : File.GetAccessControl(path, AccessControlSections.Access).GetSecurityDescriptorBinaryForm();
+                return new RawSecurityDescriptor(descriptor, 0);
+            }
+            catch
+            {
+                return null;
+            }
         }
 
 


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->

<!-- daily-stats-summary: Proposed one high-impact winpeas vulnerability check. -->

Automated proposal for one new, high-impact `winpeas` vulnerability-detection check.

Agent research and validation summary:
PEASS winpeas new-check agent completed successfully with 52 steps. Agent Comment: Plan:
1. Audit repository guidance, winPEAS check inventory, tests, history, remotes, branches, and open upstream PRs.
2. Research and rank missing high-impact passive-detection candidates using authoritative sources.
3. Implement exactly one cohesive check with a focused test where practical.
4. Build/test, inspect the full diff, run whitespace/static validation, and record the finding through the required vulnerability tool.
The initial repository audit is complete: the worktree is clean, no repository-specific `AGENTS.md` exists, and several recent/pending winPEAS branches require duplicate review. I’m now mapping the check architecture and existing coverage before selecting candidates.
Repository and upstream PR review found no open winPEAS work. The strongest current gap is privileged shared-process service DLL replacement: winPEAS checks service executables, service registry ACLs, and writable `PATH` folders, but it does not inspect each enabled LocalSystem service’s configured `Parameters\ServiceDll`. I’m validating this candidate’s exact Windows semantics and ACL evidence before implementation.
Research confirms the evidence chain: Microsoft documents that `svchost.exe` loads DLL-backed services and that LocalSystem is the default service account; Microsoft’s file-rights documentation identifies the exact overwrite/create/delete rights; MITRE classifies weak service-file permissions as a SYSTEM-capable privilege-escalation technique. I’m implementing a bounded check that requires a genuine enabled, unprotected LocalSystem `svchost` service and evaluates effective DLL/parent ACL rights without opening secret contents or triggering the service.
Implementation is in place with bounded enumeration (4,096 services / 64 findings), local-drive-only path handling, 32/64-bit `System32` redirection handling, protected-service and manifest exclusions, and ordered effective-DACL evaluation. I’m now reviewing the complete diff and compiling/testing with whatever compatible tooling is available.
The focused helper and regression suite compile under the available Mono C# compiler, and all three deterministic test methods pass. A full solution build was attempted after restoring packages, but Linux `xbuild` cannot authoritatively build this C# 8/.NET Framework 4.8 Windows solution; I’m cleaning temporary artifacts and performing the final static/diff review.
Plan update: implementation and focused validation are complete. I’m performing the final repository hygiene and diff review now, then I’ll report the selected check, evidence, files, and the Linux build limitation accurately.
## Implemented check

**Writable or plantable DLLs loaded by enabled, unprotected LocalSystem `svchost.exe` services** — MITRE ATT&CK **T1574.010**.

This is exceptionally relevant because replacing an existing `ServiceDll`, or planting a missing one, can cause attacker-controlled code to execute as **SYSTEM** when the service starts. Repository history, remote branches, and open PEASS pull requests were reviewed to avoid duplicating existing or pending checks.

### Detection behavior

The new check passively:

- Enumerates service registry entries with strict safety caps.
- Requires shared-process `svchost.exe`, LocalSystem, non-disabled, non-protected services.
- Resolves `ServiceDll` paths, environment variables, and 32/64-bit filesystem redirection.
- Rejects UNC/device/unresolved paths, avoiding network access.
- Reads only filesystem ACLs—no file contents, writes, service actions, or exploitation.
- Reports concrete effective permissions allowing:
  - Missing DLL creation.
  - Existing DLL overwrite.
  - ACL takeover.
  - Delete-and-replace operations.
- Skips `ServiceManifest` configurations whose DLL resolution may differ.

### Changed files

- `winPEAS/winPEASexe/winPEAS/Checks/ServicesInfo.cs`
- `winPEAS/winPEASexe/winPEAS/Info/ServicesInfo/ServicesInfoHelper.cs`
- `winPEAS/winPEASexe/Tests/WritableServiceDllTests.cs`
- `winPEAS/winPEASexe/Tests/winPEAS.Tests.csproj`

### Validation

- `git diff --check`: passed, including the new untracked test.
- Focused compilation of the changed helper and tests under Mono C# 7.2: passed.
- All three focused regression-test methods executed through a temporary harness: passed.
- Modified check registration/output compiled against temporary surface stubs: passed.
- Project XML, paths, delimiters, registry disposal, null/error handling, and final diff were statically reviewed.
- Restored packages and generated `bin`/`obj` artifacts were removed.
- Full solution build was attempted but could not complete under Linux because the legacy MSBuild/Fody/Roslyn toolchain requires Windows-compatible behavior. No claim is made that authoritative Windows/MSBuild validation ran locally.

### Sources

- [Microsoft: Service Programs](https://learn.microsoft.com/en-us/windows/win32/services/service-programs)
- [Microsoft: Service Host grouping and DLL-hosted services](https://learn.microsoft.com/en-us/windows/application-management/svchost-service-refactoring)
- [Microsoft: CreateServiceA service accounts and start types](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-createservicea)
- [Microsoft: File access rights constants](https://learn.microsoft.com/en-us/windows/win32/fileio/file-access-rights-constants)
- [MITRE ATT&CK T1574.010](https://attack.mitre.org/techniques/T1574/010/)
- [Geoff Chappell: svchost ServiceDll resolution](https://www.geoffchappell.com/studies/windows/win32/services/svchost/index.htm)

Generated by the PEASS New Vulnerability Checks workflow. This PR must pass PEASS PR-tests and normal Chack-Agent review.
