### PR TITLE
new-check(linpeas): add high-impact vulnerability detection

### DIFF
--- a/linPEAS/builder/linpeas_parts/1_system_information/7_Mounts.sh
+++ b/linPEAS/builder/linpeas_parts/1_system_information/7_Mounts.sh
@@ -2,7 +2,7 @@
 # ID: SY_Mounts
 # Author: Carlos Polop
 # Last Update: 07-03-2024
-# Description: Check for mount point misconfigurations that could lead to privilege escalation:
+# Description: Check for mount point misconfigurations that could lead to privilege escalation and udisks2 CVE-2026-7867 exposure:
 #   - Unmounted filesystems
 #   - Mount point permissions
 #   - Mount options
@@ -24,15 +24,19 @@
 #       - Mount option exploitation
 #       - Shared mount abuse
 # License: GNU GPL
-# Version: 1.0
-# Mitre: T1082,T1120
-# Functions Used: print_2title, print_info
-# Global Variables: $DEBUG, $mountG, $mountpermsB, $mountpermsG, $notmounted, $Wfolders, $mounted
+# Version: 1.1
+# Mitre: T1068,T1082,T1120
+# Functions Used: checkUDisksCVE20267867, print_2title, print_info
+# Global Variables: $DEBUG, $SEARCH_IN_FOLDER, $mountG, $mountpermsB, $mountpermsG, $notmounted, $Wfolders, $mounted
 # Initial Functions:
 # Generated Global Variables:
 # Fat linpeas: 0
 # Small linpeas: 1
 
+
+if ! [ "$SEARCH_IN_FOLDER" ]; then
+    checkUDisksCVE20267867
+fi
 
 if [ -f "/etc/fstab" ] || [ "$DEBUG" ]; then
     print_2title "Unmounted file-system?" "T1082,T1120"

--- a/linPEAS/builder/linpeas_parts/functions/checkUDisksCVE20267867.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkUDisksCVE20267867.sh
@@ -1,0 +1,158 @@
+# Title: Functions - checkUDisksCVE20267867
+# ID: checkUDisksCVE20267867
+# Author: Chack Agent
+# Last Update: 05-09-2026
+# Description: Passively identify complete udisks2 as-user authorization-bypass exposure (CVE-2026-7867).
+# License: GNU GPL
+# Version: 1.0
+# Mitre: T1068
+# Functions Used: print_3title, print_info
+# Global Variables: $E, $ROOT_FOLDER, $SED_LIGHT_CYAN, $SED_RED_YELLOW
+# Initial Functions:
+# Generated Global Variables: $ud7867_binary, $ud7867_binary_candidate, $ud7867_codename, $ud7867_distro_id, $ud7867_dpkg_fixed, $ud7867_dpkg_record, $ud7867_fstab, $ud7867_fstab_matches, $ud7867_full_version, $ud7867_manager, $ud7867_os_release, $ud7867_root, $ud7867_rpm_record, $ud7867_service_file, $ud7867_status, $ud7867_ubuntu_codename, $ud7867_upstream_version
+# Fat linpeas: 0
+# Small linpeas: 1
+
+
+ud7867_extract_upstream_version() {
+  printf '%s' "$1" | sed -E 's/^[0-9]+://; s/^[^0-9]*//; s/[^0-9.].*$//'
+}
+
+ud7867_version_lt() {
+  [ -n "$1" ] && [ -n "$2" ] || return 1
+  awk -v ud7867_a="$1" -v ud7867_b="$2" 'BEGIN {
+    ud7867_na = split(ud7867_a, ud7867_av, ".")
+    ud7867_nb = split(ud7867_b, ud7867_bv, ".")
+    ud7867_n = ud7867_na > ud7867_nb ? ud7867_na : ud7867_nb
+    for (ud7867_i = 1; ud7867_i <= ud7867_n; ud7867_i++) {
+      ud7867_ai = ud7867_av[ud7867_i] + 0
+      ud7867_bi = ud7867_bv[ud7867_i] + 0
+      if (ud7867_ai < ud7867_bi) exit 0
+      if (ud7867_ai > ud7867_bi) exit 1
+    }
+    exit 1
+  }'
+}
+
+ud7867_fixed_dpkg_version() {
+  # Known vendor backports from Debian DSA-6414-1 and Ubuntu USN-8701-1.
+  case "$1:$2" in
+    debian:trixie) echo "2.10.1-12.1+deb13u2" ;;
+    debian:forky|debian:sid) echo "2.11.2-1" ;;
+    ubuntu:noble) echo "2.10.1-6ubuntu1.5" ;;
+    ubuntu:resolute) echo "2.10.91-1ubuntu2.1" ;;
+  esac
+}
+
+checkUDisksCVE20267867() {
+  [ "$(uname -s 2>/dev/null)" = "Linux" ] || return 0
+
+  ud7867_root="${ROOT_FOLDER:-/}"
+  case "$ud7867_root" in
+    */) ;;
+    *) ud7867_root="${ud7867_root}/" ;;
+  esac
+
+  ud7867_fstab="${ud7867_root}etc/fstab"
+  [ -r "$ud7867_fstab" ] || return 0
+  ud7867_fstab_matches="$(awk '
+    /^[[:space:]]*#/ || NF < 4 { next }
+    {
+      ud7867_count = split($4, ud7867_options, ",")
+      for (ud7867_i = 1; ud7867_i <= ud7867_count; ud7867_i++) {
+        if (ud7867_options[ud7867_i] == "user" ||
+            ud7867_options[ud7867_i] == "users" ||
+            ud7867_options[ud7867_i] == "x-udisks-auth") {
+          print
+          next
+        }
+      }
+    }
+  ' "$ud7867_fstab" 2>/dev/null | head -n 10)"
+  [ -n "$ud7867_fstab_matches" ] || return 0
+
+  ud7867_binary=""
+  for ud7867_binary_candidate in usr/libexec/udisks2/udisksd usr/lib/udisks2/udisksd lib/udisks2/udisksd; do
+    if [ -x "${ud7867_root}${ud7867_binary_candidate}" ]; then
+      ud7867_binary="${ud7867_root}${ud7867_binary_candidate}"
+      break
+    fi
+  done
+  [ -n "$ud7867_binary" ] || return 0
+
+  ud7867_service_file="${ud7867_root}usr/share/dbus-1/system-services/org.freedesktop.UDisks2.service"
+  [ -r "$ud7867_service_file" ] || return 0
+
+  ud7867_full_version=""
+  ud7867_manager=""
+  if command -v dpkg-query >/dev/null 2>&1; then
+    ud7867_dpkg_record="$(dpkg-query --admindir="${ud7867_root}var/lib/dpkg" -W -f='$''{Status}|$''{Version}\n' udisks2 2>/dev/null | head -n1)"
+    case "$ud7867_dpkg_record" in
+      "install ok installed|"*)
+        ud7867_full_version="${ud7867_dpkg_record#*|}"
+        [ -n "$ud7867_full_version" ] && ud7867_manager="dpkg"
+        ;;
+    esac
+  fi
+  if [ -z "$ud7867_full_version" ] && command -v rpm >/dev/null 2>&1; then
+    if ud7867_rpm_record="$(rpm --root "$ud7867_root" -q --qf '%{VERSION}-%{RELEASE}\n' udisks2 2>/dev/null)"; then
+      ud7867_full_version="$(printf '%s\n' "$ud7867_rpm_record" | head -n1)"
+      [ -n "$ud7867_full_version" ] && ud7867_manager="rpm"
+    fi
+  fi
+  [ -n "$ud7867_full_version" ] || return 0
+
+  ud7867_os_release="${ud7867_root}etc/os-release"
+  ud7867_distro_id="$(sed -nE 's/^ID="?([^" ]+)"?$/\1/p' "$ud7867_os_release" 2>/dev/null | head -n1)"
+  ud7867_codename="$(sed -nE 's/^VERSION_CODENAME="?([^" ]+)"?$/\1/p' "$ud7867_os_release" 2>/dev/null | head -n1)"
+  ud7867_ubuntu_codename="$(sed -nE 's/^UBUNTU_CODENAME="?([^" ]+)"?$/\1/p' "$ud7867_os_release" 2>/dev/null | head -n1)"
+  if [ -n "$ud7867_ubuntu_codename" ]; then
+    ud7867_distro_id="ubuntu"
+    ud7867_codename="$ud7867_ubuntu_codename"
+  fi
+
+  ud7867_upstream_version="$(ud7867_extract_upstream_version "$ud7867_full_version")"
+  ud7867_dpkg_fixed=""
+  ud7867_status="unknown"
+
+  if [ "$ud7867_manager" = "dpkg" ] && command -v dpkg >/dev/null 2>&1; then
+    ud7867_dpkg_fixed="$(ud7867_fixed_dpkg_version "$ud7867_distro_id" "$ud7867_codename")"
+    if [ -n "$ud7867_dpkg_fixed" ]; then
+      if dpkg --compare-versions "$ud7867_full_version" lt "$ud7867_dpkg_fixed"; then
+        ud7867_status="affected"
+      else
+        ud7867_status="fixed"
+      fi
+    fi
+  fi
+
+  # RPM vendors commonly retain their old upstream version after backporting.
+  if [ "$ud7867_status" = "unknown" ] && [ "$ud7867_manager" = "rpm" ]; then
+    if rpm --root "$ud7867_root" -q --changelog udisks2 2>/dev/null | grep -q 'CVE-2026-7867'; then
+      ud7867_status="fixed"
+    fi
+  fi
+
+  if [ "$ud7867_status" = "unknown" ] && [ -n "$ud7867_upstream_version" ]; then
+    if ud7867_version_lt "$ud7867_upstream_version" "2.10.0"; then
+      ud7867_status="fixed"
+    elif ud7867_version_lt "$ud7867_upstream_version" "2.11.2"; then
+      ud7867_status="potential"
+    else
+      ud7867_status="fixed"
+    fi
+  fi
+  [ "$ud7867_status" = "affected" ] || [ "$ud7867_status" = "potential" ] || return 0
+
+  print_3title "UDisks as-user mount authorization bypass (CVE-2026-7867)" "T1068"
+  print_info "https://github.com/storaged-project/udisks/security/advisories/GHSA-j42g-v9jw-6ph3"
+  echo "udisks2 package: $ud7867_full_version ($ud7867_manager)" | sed -${E} "s,.*,${SED_LIGHT_CYAN},"
+  if [ "$ud7867_status" = "affected" ]; then
+    echo "VULNERABLE to CVE-2026-7867: package is below the known vendor fixed version and a qualifying fstab entry is present" | sed -${E} "s,.*,${SED_RED_YELLOW},"
+  else
+    echo "Potentially vulnerable to CVE-2026-7867: upstream version is in the affected range 2.10.0 through 2.11.1; verify vendor backports" | sed -${E} "s,.*,${SED_RED_YELLOW},"
+  fi
+  echo "Qualifying /etc/fstab entries (maximum 10):"
+  printf '%s\n' "$ud7867_fstab_matches"
+  echo ""
+}

--- a/linPEAS/tests/test_udisks.py
+++ b/linPEAS/tests/test_udisks.py
@@ -1,0 +1,185 @@
+import os
+import shlex
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class UDisksCVE20267867Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.repo_root = Path(__file__).resolve().parents[2]
+        cls.function_file = (
+            cls.repo_root
+            / "linPEAS"
+            / "builder"
+            / "linpeas_parts"
+            / "functions"
+            / "checkUDisksCVE20267867.sh"
+        )
+
+    def _make_root(self, base, options="defaults,user"):
+        root = base / "root"
+        (root / "etc").mkdir(parents=True)
+        (root / "etc" / "fstab").write_text(
+            f"UUID=test /media/test ext4 {options} 0 2\n", encoding="utf-8"
+        )
+        (root / "etc" / "os-release").write_text(
+            'ID=ubuntu\nVERSION_CODENAME=noble\nVERSION_ID="24.04"\n',
+            encoding="utf-8",
+        )
+        (root / "var" / "lib" / "dpkg").mkdir(parents=True)
+        daemon = root / "usr" / "libexec" / "udisks2" / "udisksd"
+        daemon.parent.mkdir(parents=True)
+        daemon.write_text('#!/bin/sh\ntouch "$EXECUTED_MARKER"\n', encoding="utf-8")
+        daemon.chmod(0o755)
+        service = (
+            root
+            / "usr"
+            / "share"
+            / "dbus-1"
+            / "system-services"
+            / "org.freedesktop.UDisks2.service"
+        )
+        service.parent.mkdir(parents=True)
+        service.write_text(
+            "[D-BUS Service]\nName=org.freedesktop.UDisks2\nExec=/usr/libexec/udisks2/udisksd\n",
+            encoding="utf-8",
+        )
+        return root
+
+    def _run_check(self, root, package_version, older_than_vendor_fix):
+        bindir = root.parent / "bin"
+        bindir.mkdir()
+        dpkg_query = bindir / "dpkg-query"
+        dpkg_query.write_text(
+            '#!/bin/sh\nprintf "%s|%s\\n" "$FAKE_UDISKS_STATUS" "$FAKE_UDISKS_VERSION"\n',
+            encoding="utf-8",
+        )
+        dpkg_query.chmod(0o755)
+        dpkg = bindir / "dpkg"
+        dpkg.write_text(
+            '#!/bin/sh\n'
+            'if [ "$1" = "--compare-versions" ]; then\n'
+            '  [ "$FAKE_DPKG_VERSION_IS_OLDER" = "1" ]\n'
+            '  exit\n'
+            'fi\n'
+            'exit 1\n',
+            encoding="utf-8",
+        )
+        dpkg.chmod(0o755)
+        rpm = bindir / "rpm"
+        rpm.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        rpm.chmod(0o755)
+
+        marker = root.parent / "executed"
+        env = os.environ.copy()
+        env.update(
+            {
+                "EXECUTED_MARKER": str(marker),
+                "FAKE_UDISKS_STATUS": "install ok installed",
+                "FAKE_UDISKS_VERSION": package_version,
+                "FAKE_DPKG_VERSION_IS_OLDER": "1" if older_than_vendor_fix else "0",
+                "PATH": f"{bindir}:{env['PATH']}",
+            }
+        )
+        body = "\n".join(
+            [
+                f"ROOT_FOLDER={shlex.quote(str(root))}",
+                "E=E",
+                "SED_LIGHT_CYAN='&'",
+                "SED_RED_YELLOW='&'",
+                'print_3title() { echo "TITLE: $1"; }',
+                "print_info() { :; }",
+                f". {shlex.quote(str(self.function_file))}",
+                "checkUDisksCVE20267867",
+            ]
+        )
+        result = subprocess.run(
+            ["sh", "-c", body],
+            cwd=str(self.repo_root),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result, marker
+
+    def test_vulnerable_ubuntu_package_and_fstab_entry_are_reported_passively(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir))
+            result, marker = self._run_check(root, "2.10.1-6ubuntu1.4", True)
+            self.assertFalse(marker.exists(), "udisksd must never be executed")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("TITLE: UDisks as-user mount authorization bypass", result.stdout)
+        self.assertIn("VULNERABLE to CVE-2026-7867", result.stdout)
+        self.assertIn("UUID=test /media/test ext4 defaults,user 0 2", result.stdout)
+
+    def test_vendor_fixed_ubuntu_package_is_suppressed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir))
+            result, _ = self._run_check(root, "2.10.1-6ubuntu1.5", False)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual("", result.stdout)
+
+    def test_unaffected_pre_210_upstream_version_is_suppressed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir))
+            (root / "etc" / "os-release").write_text(
+                "ID=debian\nVERSION_CODENAME=bookworm\n", encoding="utf-8"
+            )
+            result, _ = self._run_check(root, "2.9.4-4+deb12u2", False)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual("", result.stdout)
+
+    def test_nonqualifying_nouser_option_is_suppressed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir), options="defaults,nouser")
+            result, _ = self._run_check(root, "2.10.1-6ubuntu1.4", True)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual("", result.stdout)
+
+    def test_missing_dbus_activation_service_is_suppressed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = self._make_root(Path(tmpdir))
+            (
+                root
+                / "usr"
+                / "share"
+                / "dbus-1"
+                / "system-services"
+                / "org.freedesktop.UDisks2.service"
+            ).unlink()
+            result, _ = self._run_check(root, "2.10.1-6ubuntu1.4", True)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual("", result.stdout)
+
+    def test_version_comparison_handles_double_digit_components(self):
+        body = "\n".join(
+            [
+                f". {shlex.quote(str(self.function_file))}",
+                "ud7867_version_lt 2.10.91 2.11.2 && echo old=yes",
+                "ud7867_version_lt 2.11.10 2.11.2 || echo new=yes",
+            ]
+        )
+        result = subprocess.run(
+            ["sh", "-c", body],
+            cwd=str(self.repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("old=yes", result.stdout)
+        self.assertIn("new=yes", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->

<!-- daily-stats-summary: Proposed one high-impact linpeas vulnerability check. -->

Automated proposal for one new, high-impact `linpeas` vulnerability-detection check.

Agent research and validation summary:
PEASS linpeas new-check agent completed successfully with 19 steps. Agent Comment: Plan:
1. Audit repository guidance, current linPEAS checks, history, branches, and open PRs.
2. Research and rank high-impact passive-detection candidates using authoritative sources.
3. Implement exactly one focused check and a deterministic regression test if practical.
4. Run syntax, unit-test, full test-discovery, builder, and diff validation; fix all failures.
Audit is underway. I found a clean working tree, the supplied origin, several recent automated linPEAS check branches, and no repository-specific `AGENTS.md`; next I’m mapping module metadata and current vulnerability coverage before choosing a candidate.
The duplication review is complete: the only open PR is parser-only, while older unmerged branches cover refactors or checks already merged into `master` (snap-confine, needrestart, CIFSwitch). I’m now ranking missing conditions, prioritizing broad deployment, strong privilege impact, and locally reliable evidence rather than adding another noisy version-only warning.
Candidate selection is complete. I rejected the newly disclosed XFS `CVE-2026-80530` because its `exchange_range` filesystem feature is experimental and off by default. The strongest missing check is `CVE-2026-7867`: a high-severity udisks2 authorization bypass affecting common desktop storage workflows, with a precise three-part passive signature—affected package, D-Bus daemon availability, and a qualifying `/etc/fstab` option.
Implementation is in place as one cohesive check in the existing mounts module, with a helper and six focused tests. Initial shell syntax, metadata validation, and targeted tests pass; I’m now running the full linPEAS suite and building to `/tmp`, then I’ll inspect the generated placement and complete diff.
The combined validation exceeded the shell tool’s five-minute synchronous limit before returning output. I’m splitting it into monitored background runs so the required full suite and builder can finish without weakening or skipping either validation step.

Generated by the PEASS New Vulnerability Checks workflow. This PR must pass PEASS PR-tests and normal Chack-Agent review.
