### PR TITLE
wordlist-updater: refresh linpeas vulnerability lists

### DIFF
--- a/linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh
+++ b/linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh
@@ -2,7 +2,7 @@
 # ID: kernel_cve_registry_data
 # Author: Carlos Polop
 # Contributor: Arjay Saguisa
-# Last Update: 05-09-2026
+# Last Update: 07-09-2026
 # Description: Embedded kernel exploit matching datasets extracted from linux-exploit-suggester and linux-exploit-suggester-2 examples. Data is split across KERNEL_CVE_DATA_1..X with a maximum of 25 rows per env variable. This file also stores reference-only CVE tokens found in example repos when no explicit suggester matching rule exists.
 # License: GNU GPL
 # Version: 1.0
@@ -676,27 +676,27 @@ EOF_DATA_23
 )"
 
 KERNEL_CVE_DATA_24="$(cat <<'EOF_DATA_24'
-CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=5.15.180,ver<5.15.212,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tFixed in stable 5.15.212; public exploit requires Open vSwitch and unprivileged network namespaces
-CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=6.1.132,ver<6.1.178,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tFixed in stable 6.1.178; public exploit requires Open vSwitch and unprivileged network namespaces
-CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=6.6.84,ver<6.6.145,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tFixed in stable 6.6.145; public exploit requires Open vSwitch and unprivileged network namespaces
-CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=6.12.20,ver<6.12.97,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tFixed in stable 6.12.97; public exploit requires Open vSwitch and unprivileged network namespaces
-CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=6.13.8,ver<6.14,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tAffected stable 6.13 range; public exploit requires Open vSwitch and unprivileged network namespaces
-CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=6.14,ver<6.18.40,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tFixed in stable 6.18.40; public exploit requires Open vSwitch and unprivileged network namespaces
-CVE-2026-64531\tOVSwrap Open vSwitch nested-action overflow\tpkg=linux-kernel,ver>=6.19,ver<7.1.5,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1\t\t1\tFixed in stable 7.1.5 and mainline 7.2; public exploit requires Open vSwitch and unprivileged network namespaces
-CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=2.6.25,ver<5.10.265,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 5.10.265; SCTP support is required and public exploit targets may require adaptation
-CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=5.11,ver<5.15.216,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 5.15.216; SCTP support is required and public exploit targets may require adaptation
-CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=5.16,ver<6.1.183,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 6.1.183; SCTP support is required and public exploit targets may require adaptation
-CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=6.2,ver<6.6.148,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 6.6.148; SCTP support is required and public exploit targets may require adaptation
-CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=6.7,ver<6.12.101,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 6.12.101; SCTP support is required and public exploit targets may require adaptation
-CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=6.13,ver<6.18.42,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 6.18.42; SCTP support is required and public exploit targets may require adaptation
-CVE-2026-64564\tSCTPhantom SCTP ASCONF transport UAF\tpkg=linux-kernel,ver>=6.19,ver<7.1.6,CONFIG_IP_SCTP=[my]\t\t1\tFixed in stable 7.1.6 and mainline 7.2; SCTP support is required and public exploit targets may require adaptation
-CVE-2026-53365\tVsockDrop virtio-vsock zerocopy refcount flaw\tpkg=linux-kernel,ver>=6.7,ver<6.12.97,CONFIG_VSOCKETS=[my],CONFIG_VIRTIO_VSOCKETS=[my],CONFIG_IO_URING=y\t\t1\tFixed in stable 6.12.97; public exploit uses io_uring and AF_VSOCK
-CVE-2026-53365\tVsockDrop virtio-vsock zerocopy refcount flaw\tpkg=linux-kernel,ver>=6.13,ver<6.18.34,CONFIG_VSOCKETS=[my],CONFIG_VIRTIO_VSOCKETS=[my],CONFIG_IO_URING=y\t\t1\tFixed in stable 6.18.34; public exploit uses io_uring and AF_VSOCK
-CVE-2026-53365\tVsockDrop virtio-vsock zerocopy refcount flaw\tpkg=linux-kernel,ver>=6.19,ver<7.0.11,CONFIG_VSOCKETS=[my],CONFIG_VIRTIO_VSOCKETS=[my],CONFIG_IO_URING=y\t\t1\tFixed in stable 7.0.11 and mainline 7.1; public exploit uses io_uring and AF_VSOCK
-CVE-2026-53361\tBadGarbage AF_UNIX garbage-collector race\tpkg=linux-kernel,ver>=6.1.141,ver<6.1.183\t\t1\tFixed in stable 6.1.183; public exploit can provide local root and container escape
-CVE-2026-53361\tBadGarbage AF_UNIX garbage-collector race\tpkg=linux-kernel,ver>=6.6.93,ver<6.6.144\t\t1\tFixed in stable 6.6.144; public exploit can provide local root and container escape
-CVE-2026-53361\tBadGarbage AF_UNIX garbage-collector race\tpkg=linux-kernel,ver>=6.9,ver<6.12.95\t\t1\tFixed in stable 6.12.95; public exploit can provide local root and container escape
-CVE-2026-53361\tBadGarbage AF_UNIX garbage-collector race\tpkg=linux-kernel,ver>=6.13,ver<6.18.38\t\t1\tFixed in stable 6.18.38; public exploit can provide local root and container escape
-CVE-2026-53361\tBadGarbage AF_UNIX garbage-collector race\tpkg=linux-kernel,ver>=6.19,ver<7.1\t\t1\tFixed in mainline 7.1; public exploit can provide local root and container escape
+CVE-2026-64531	OVSwrap Open vSwitch nested-action overflow	pkg=linux-kernel,ver>=5.15.180,ver<5.15.212,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1		1	Fixed in stable 5.15.212; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64531	OVSwrap Open vSwitch nested-action overflow	pkg=linux-kernel,ver>=6.1.132,ver<6.1.178,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1		1	Fixed in stable 6.1.178; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64531	OVSwrap Open vSwitch nested-action overflow	pkg=linux-kernel,ver>=6.6.84,ver<6.6.145,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1		1	Fixed in stable 6.6.145; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64531	OVSwrap Open vSwitch nested-action overflow	pkg=linux-kernel,ver>=6.12.20,ver<6.12.97,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1		1	Fixed in stable 6.12.97; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64531	OVSwrap Open vSwitch nested-action overflow	pkg=linux-kernel,ver>=6.13.8,ver<6.14,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1		1	Affected stable 6.13 range; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64531	OVSwrap Open vSwitch nested-action overflow	pkg=linux-kernel,ver>=6.14,ver<6.18.40,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1		1	Fixed in stable 6.18.40; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64531	OVSwrap Open vSwitch nested-action overflow	pkg=linux-kernel,ver>=6.19,ver<7.1.5,x86_64,CONFIG_OPENVSWITCH=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1		1	Fixed in stable 7.1.5 and mainline 7.2; public exploit requires Open vSwitch and unprivileged network namespaces
+CVE-2026-64564	SCTPhantom SCTP ASCONF transport UAF	pkg=linux-kernel,ver>=2.6.25,ver<5.10.265,CONFIG_IP_SCTP=[my]		1	Fixed in stable 5.10.265; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-64564	SCTPhantom SCTP ASCONF transport UAF	pkg=linux-kernel,ver>=5.11,ver<5.15.216,CONFIG_IP_SCTP=[my]		1	Fixed in stable 5.15.216; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-64564	SCTPhantom SCTP ASCONF transport UAF	pkg=linux-kernel,ver>=5.16,ver<6.1.183,CONFIG_IP_SCTP=[my]		1	Fixed in stable 6.1.183; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-64564	SCTPhantom SCTP ASCONF transport UAF	pkg=linux-kernel,ver>=6.2,ver<6.6.148,CONFIG_IP_SCTP=[my]		1	Fixed in stable 6.6.148; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-64564	SCTPhantom SCTP ASCONF transport UAF	pkg=linux-kernel,ver>=6.7,ver<6.12.101,CONFIG_IP_SCTP=[my]		1	Fixed in stable 6.12.101; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-64564	SCTPhantom SCTP ASCONF transport UAF	pkg=linux-kernel,ver>=6.13,ver<6.18.42,CONFIG_IP_SCTP=[my]		1	Fixed in stable 6.18.42; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-64564	SCTPhantom SCTP ASCONF transport UAF	pkg=linux-kernel,ver>=6.19,ver<7.1.6,CONFIG_IP_SCTP=[my]		1	Fixed in stable 7.1.6 and mainline 7.2; SCTP support is required and public exploit targets may require adaptation
+CVE-2026-53365	VsockDrop virtio-vsock zerocopy refcount flaw	pkg=linux-kernel,ver>=6.7,ver<6.12.97,CONFIG_VSOCKETS=[my],CONFIG_VIRTIO_VSOCKETS=[my],CONFIG_IO_URING=y		1	Fixed in stable 6.12.97; public exploit uses io_uring and AF_VSOCK
+CVE-2026-53365	VsockDrop virtio-vsock zerocopy refcount flaw	pkg=linux-kernel,ver>=6.13,ver<6.18.34,CONFIG_VSOCKETS=[my],CONFIG_VIRTIO_VSOCKETS=[my],CONFIG_IO_URING=y		1	Fixed in stable 6.18.34; public exploit uses io_uring and AF_VSOCK
+CVE-2026-53365	VsockDrop virtio-vsock zerocopy refcount flaw	pkg=linux-kernel,ver>=6.19,ver<7.0.11,CONFIG_VSOCKETS=[my],CONFIG_VIRTIO_VSOCKETS=[my],CONFIG_IO_URING=y		1	Fixed in stable 7.0.11 and mainline 7.1; public exploit uses io_uring and AF_VSOCK
+CVE-2026-53361	BadGarbage AF_UNIX garbage-collector race	pkg=linux-kernel,ver>=6.1.141,ver<6.1.183		1	Fixed in stable 6.1.183; public exploit can provide local root and container escape
+CVE-2026-53361	BadGarbage AF_UNIX garbage-collector race	pkg=linux-kernel,ver>=6.6.93,ver<6.6.144		1	Fixed in stable 6.6.144; public exploit can provide local root and container escape
+CVE-2026-53361	BadGarbage AF_UNIX garbage-collector race	pkg=linux-kernel,ver>=6.9,ver<6.12.95		1	Fixed in stable 6.12.95; public exploit can provide local root and container escape
+CVE-2026-53361	BadGarbage AF_UNIX garbage-collector race	pkg=linux-kernel,ver>=6.13,ver<6.18.38		1	Fixed in stable 6.18.38; public exploit can provide local root and container escape
+CVE-2026-53361	BadGarbage AF_UNIX garbage-collector race	pkg=linux-kernel,ver>=6.19,ver<7.1		1	Fixed in mainline 7.1; public exploit can provide local root and container escape
 EOF_DATA_24
 )"


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->\n<!-- daily-stats-summary: Refreshed LinPEAS vulnerability wordlists. -->\n\nAutomated LinPEAS vulnerability wordlist refresh.\n\nAgent summary:\nPEASS linpeas wordlist updater completed successfully with 37 steps. Agent Comment: Plan:
1. Locate the maintained source lists, usage sites, repository guidance, and 30-day history.
2. Audit current entries against recent authoritative advisories and upstream security data.
3. Make only high-confidence list-data edits, then review the diff.
4. Build LinPEAS and run focused validation before reporting exact changes.
Repository review is complete: the current branch already contains two intentional kernel-registry refreshes inside the 30-day window (August 17 and September 5), plus a September 5 SUID refresh. I’ll preserve those additions and now compare the maintained data with current upstream/advisory state.
Audit result: no new high-confidence sudo/SUID version boundary is needed, and the maintained exploit-suggester datasets contain no CVE tokens absent from LinPEAS. However, the September 5 kernel refresh introduced a concrete data-format defect: all 22 rows in `KERNEL_CVE_DATA_24` contain literal `\t` text instead of tab delimiters, so the existing tab-based registry parser cannot split or evaluate those new rules. I’ll make the minimal delimiter repair and validate it before building.
The repaired chunk now sources as 22 valid six-field records; all CVE rows in the registry pass the delimiter/schema check, and shell syntax plus `git diff --check` are clean. I’m proceeding with the requested full LinPEAS build.
### Files updated
- `linPEAS/builder/linpeas_parts/variables/kernel_cve_registry_data.sh`
  - Replaced literal `\t` strings with real tab delimiters across all 22 `KERNEL_CVE_DATA_24` records.
  - Restored parsing for CVE-2026-64531, CVE-2026-64564, CVE-2026-53365, and CVE-2026-53361.
  - Updated the file date to `07-09-2026`.

### Skipped
- `sidB.sh`: Already refreshed September 5; no reliable newer entries found.
- `sudovB.sh`: Existing regex already covers affected sudo versions through 1.9.17p2, consistent with the [Red Hat CVE-2026-35535 record](https://access.redhat.com/security/cve/CVE-2026-35535).
- No other maintained static lists required changes.

### Validation
- All 22 repaired rows source as valid six-field records.
- `bash -n` and `git diff --check`: passed.
- Full LinPEAS build: **passed**.
- Output: `/tmp/linpeas_fat.sh` (1,155,309 bytes); generated script also passed `bash -n`.
- Only the kernel registry source file is modified.\n\nGenerated by PEASS wordlist updater workflow.