### PR TITLE
autoimprover: simplify linpeas checks

### DIFF
--- a/linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkNeedrestartCVE202448990.sh
@@ -1,38 +1,17 @@
 # Title: Functions - checkNeedrestartCVE202448990
 # ID: checkNeedrestartCVE202448990
 # Author: Chack Agent
-# Last Update: 24-08-2026
+# Last Update: 07-09-2026
 # Description: Passively identify needrestart interpreter-scanner local privilege-escalation exposure, including CVE-2024-48990.
 # License: GNU GPL
-# Version: 1.1
+# Version: 1.2
 # Mitre: T1068
-# Functions Used: print_3title, print_info
+# Functions Used: lp_extract_upstream_version, lp_version_lt, print_3title, print_info
 # Global Variables: $E, $ROOT_FOLDER, $SED_GREEN, $SED_LIGHT_CYAN, $SED_RED_YELLOW, $SED_YELLOW
 # Initial Functions:
 # Generated Global Variables: $nr48990_binary, $nr48990_binary_candidate, $nr48990_codename, $nr48990_config, $nr48990_config_file, $nr48990_config_file_value, $nr48990_distro_id, $nr48990_dpkg_fixed, $nr48990_dpkg_record, $nr48990_full_version, $nr48990_interpscan, $nr48990_manager, $nr48990_os_release, $nr48990_root, $nr48990_rpm_record, $nr48990_status, $nr48990_ubuntu_codename, $nr48990_upstream_version
 # Fat linpeas: 0
 # Small linpeas: 1
-
-
-nr48990_extract_upstream_version() {
-  printf '%s' "$1" | sed -E 's/^[0-9]+://; s/^[^0-9]*//; s/[^0-9.].*$//'
-}
-
-nr48990_version_lt() {
-  [ -n "$1" ] && [ -n "$2" ] || return 1
-  awk -v nr48990_a="$1" -v nr48990_b="$2" 'BEGIN {
-    nr48990_na = split(nr48990_a, nr48990_av, ".")
-    nr48990_nb = split(nr48990_b, nr48990_bv, ".")
-    nr48990_n = nr48990_na > nr48990_nb ? nr48990_na : nr48990_nb
-    for (nr48990_i = 1; nr48990_i <= nr48990_n; nr48990_i++) {
-      nr48990_ai = nr48990_av[nr48990_i] + 0
-      nr48990_bi = nr48990_bv[nr48990_i] + 0
-      if (nr48990_ai < nr48990_bi) exit 0
-      if (nr48990_ai > nr48990_bi) exit 1
-    }
-    exit 1
-  }'
-}
 
 nr48990_fixed_dpkg_version() {
   # Vendor backports from Ubuntu CVE-2024-48990 and Debian DSA-5815-1 /
@@ -121,7 +100,7 @@ checkNeedrestartCVE202448990() {
     nr48990_codename="$nr48990_ubuntu_codename"
   fi
 
-  nr48990_upstream_version="$(nr48990_extract_upstream_version "$nr48990_full_version")"
+  nr48990_upstream_version="$(lp_extract_upstream_version "$nr48990_full_version")"
   nr48990_interpscan="$(nr48990_effective_interpscan "$nr48990_root")"
   nr48990_dpkg_fixed=""
   nr48990_status="unknown"
@@ -137,7 +116,7 @@ checkNeedrestartCVE202448990() {
     fi
   fi
   if [ "$nr48990_status" = "unknown" ] && [ -n "$nr48990_upstream_version" ]; then
-    if nr48990_version_lt "$nr48990_upstream_version" "3.8"; then
+    if lp_version_lt "$nr48990_upstream_version" "3.8"; then
       nr48990_status="potential"
     else
       nr48990_status="fixed"

--- a/linPEAS/builder/linpeas_parts/functions/checkSnapConfineCVE20268933.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkSnapConfineCVE20268933.sh
@@ -1,22 +1,17 @@
 # Title: Functions - checkSnapConfineCVE20268933
 # ID: checkSnapConfineCVE20268933
 # Author: Chack Agent
-# Last Update: 14-08-2026
+# Last Update: 07-09-2026
 # Description: Passively identify set-capabilities snap-confine binaries exposed to CVE-2026-8933.
 # License: GNU GPL
-# Version: 1.0
+# Version: 1.1
 # Mitre: T1068
-# Functions Used: print_3title, print_info
+# Functions Used: lp_extract_upstream_version, print_3title, print_info
 # Global Variables: $E, $ROOT_FOLDER, $SED_GREEN, $SED_LIGHT_CYAN, $SED_RED_YELLOW
 # Initial Functions:
 # Generated Global Variables: $sc8933_caps, $sc8933_fixed, $sc8933_kind, $sc8933_os_id, $sc8933_os_release, $sc8933_path, $sc8933_reported, $sc8933_root, $sc8933_upstream, $sc8933_version, $sc8933_yaml
 # Fat linpeas: 0
 # Small linpeas: 1
-
-
-sc8933_extract_upstream_version() {
-  printf '%s' "$1" | sed -E 's/^[0-9]+://; s/^[^0-9]*//; s/[^0-9.].*$//'
-}
 
 sc8933_version_ge() {
   [ -n "$1" ] && [ -n "$2" ] || return 1
@@ -40,7 +35,7 @@ sc8933_version_is_vulnerable() {
   sc8933_version="$1"
   sc8933_kind="$2"
   sc8933_os_release="$3"
-  sc8933_upstream="$(sc8933_extract_upstream_version "$sc8933_version")"
+  sc8933_upstream="$(lp_extract_upstream_version "$sc8933_version")"
 
   # The upstream affected range is >= 2.75.0 and < 2.76.1. Ubuntu fixed
   # 2.76 with release-specific backports, so compare the complete dpkg version.

--- a/linPEAS/builder/linpeas_parts/functions/checkUDisksCVE20267867.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkUDisksCVE20267867.sh
@@ -1,38 +1,17 @@
 # Title: Functions - checkUDisksCVE20267867
 # ID: checkUDisksCVE20267867
 # Author: Chack Agent
-# Last Update: 05-09-2026
+# Last Update: 07-09-2026
 # Description: Passively identify complete udisks2 as-user authorization-bypass exposure (CVE-2026-7867).
 # License: GNU GPL
-# Version: 1.0
+# Version: 1.1
 # Mitre: T1068
-# Functions Used: print_3title, print_info
+# Functions Used: lp_extract_upstream_version, lp_version_lt, print_3title, print_info
 # Global Variables: $E, $ROOT_FOLDER, $SED_LIGHT_CYAN, $SED_RED_YELLOW
 # Initial Functions:
 # Generated Global Variables: $ud7867_binary, $ud7867_binary_candidate, $ud7867_codename, $ud7867_distro_id, $ud7867_dpkg_fixed, $ud7867_dpkg_record, $ud7867_fstab, $ud7867_fstab_matches, $ud7867_full_version, $ud7867_manager, $ud7867_os_release, $ud7867_root, $ud7867_rpm_record, $ud7867_service_file, $ud7867_status, $ud7867_ubuntu_codename, $ud7867_upstream_version
 # Fat linpeas: 0
 # Small linpeas: 1
-
-
-ud7867_extract_upstream_version() {
-  printf '%s' "$1" | sed -E 's/^[0-9]+://; s/^[^0-9]*//; s/[^0-9.].*$//'
-}
-
-ud7867_version_lt() {
-  [ -n "$1" ] && [ -n "$2" ] || return 1
-  awk -v ud7867_a="$1" -v ud7867_b="$2" 'BEGIN {
-    ud7867_na = split(ud7867_a, ud7867_av, ".")
-    ud7867_nb = split(ud7867_b, ud7867_bv, ".")
-    ud7867_n = ud7867_na > ud7867_nb ? ud7867_na : ud7867_nb
-    for (ud7867_i = 1; ud7867_i <= ud7867_n; ud7867_i++) {
-      ud7867_ai = ud7867_av[ud7867_i] + 0
-      ud7867_bi = ud7867_bv[ud7867_i] + 0
-      if (ud7867_ai < ud7867_bi) exit 0
-      if (ud7867_ai > ud7867_bi) exit 1
-    }
-    exit 1
-  }'
-}
 
 ud7867_fixed_dpkg_version() {
   # Known vendor backports from Debian DSA-6414-1 and Ubuntu USN-8701-1.
@@ -111,7 +90,7 @@ checkUDisksCVE20267867() {
     ud7867_codename="$ud7867_ubuntu_codename"
   fi
 
-  ud7867_upstream_version="$(ud7867_extract_upstream_version "$ud7867_full_version")"
+  ud7867_upstream_version="$(lp_extract_upstream_version "$ud7867_full_version")"
   ud7867_dpkg_fixed=""
   ud7867_status="unknown"
 
@@ -134,9 +113,9 @@ checkUDisksCVE20267867() {
   fi
 
   if [ "$ud7867_status" = "unknown" ] && [ -n "$ud7867_upstream_version" ]; then
-    if ud7867_version_lt "$ud7867_upstream_version" "2.10.0"; then
+    if lp_version_lt "$ud7867_upstream_version" "2.10.0"; then
       ud7867_status="fixed"
-    elif ud7867_version_lt "$ud7867_upstream_version" "2.11.2"; then
+    elif lp_version_lt "$ud7867_upstream_version" "2.11.2"; then
       ud7867_status="potential"
     else
       ud7867_status="fixed"

--- a/linPEAS/builder/linpeas_parts/functions/lp_extract_upstream_version.sh
+++ b/linPEAS/builder/linpeas_parts/functions/lp_extract_upstream_version.sh
@@ -1,0 +1,18 @@
+# Title: Functions - lp_extract_upstream_version
+# ID: lp_extract_upstream_version
+# Author: Chack Agent
+# Last Update: 07-09-2026
+# Description: Extract a numeric dotted upstream version from a package version.
+# License: GNU GPL
+# Version: 1.0
+# Functions Used:
+# Global Variables:
+# Initial Functions:
+# Generated Global Variables:
+# Fat linpeas: 0
+# Small linpeas: 1
+
+
+lp_extract_upstream_version() {
+  printf '%s' "$1" | sed -E 's/^[0-9]+://; s/^[^0-9]*//; s/[^0-9.].*$//'
+}

--- a/linPEAS/builder/linpeas_parts/functions/lp_version_lt.sh
+++ b/linPEAS/builder/linpeas_parts/functions/lp_version_lt.sh
@@ -1,0 +1,30 @@
+# Title: Functions - lp_version_lt
+# ID: lp_version_lt
+# Author: Chack Agent
+# Last Update: 07-09-2026
+# Description: Compare numeric dotted versions and succeed when the first is lower.
+# License: GNU GPL
+# Version: 1.0
+# Functions Used:
+# Global Variables:
+# Initial Functions:
+# Generated Global Variables:
+# Fat linpeas: 0
+# Small linpeas: 1
+
+
+lp_version_lt() {
+  [ -n "$1" ] && [ -n "$2" ] || return 1
+  awk -v lp_a="$1" -v lp_b="$2" 'BEGIN {
+    lp_na = split(lp_a, lp_av, ".")
+    lp_nb = split(lp_b, lp_bv, ".")
+    lp_n = lp_na > lp_nb ? lp_na : lp_nb
+    for (lp_i = 1; lp_i <= lp_n; lp_i++) {
+      lp_ai = lp_av[lp_i] + 0
+      lp_bi = lp_bv[lp_i] + 0
+      if (lp_ai < lp_bi) exit 0
+      if (lp_ai > lp_bi) exit 1
+    }
+    exit 1
+  }'
+}

--- a/linPEAS/tests/test_needrestart.py
+++ b/linPEAS/tests/test_needrestart.py
@@ -18,6 +18,8 @@ class NeedrestartCVE202448990Tests(unittest.TestCase):
             / "functions"
             / "checkNeedrestartCVE202448990.sh"
         )
+        cls.extract_version_helper = cls.function_file.parent / "lp_extract_upstream_version.sh"
+        cls.version_lt_helper = cls.function_file.parent / "lp_version_lt.sh"
 
     def _make_root(self, base, main_value=None, snippet_value=None):
         root = base / "root"
@@ -88,6 +90,8 @@ class NeedrestartCVE202448990Tests(unittest.TestCase):
                 "SED_YELLOW='&'",
                 'print_3title() { echo "TITLE: $1"; }',
                 "print_info() { :; }",
+                f". {shlex.quote(str(self.extract_version_helper))}",
+                f". {shlex.quote(str(self.version_lt_helper))}",
                 f". {shlex.quote(str(self.function_file))}",
                 "checkNeedrestartCVE202448990",
             ]
@@ -158,9 +162,9 @@ class NeedrestartCVE202448990Tests(unittest.TestCase):
     def test_upstream_version_comparison_handles_double_digit_components(self):
         body = "\n".join(
             [
-                f". {shlex.quote(str(self.function_file))}",
-                "nr48990_version_lt 3.7 3.8 && echo old=yes",
-                "nr48990_version_lt 3.10 3.8 || echo new=yes",
+                f". {shlex.quote(str(self.version_lt_helper))}",
+                "lp_version_lt 3.7 3.8 && echo old=yes",
+                "lp_version_lt 3.10 3.8 || echo new=yes",
             ]
         )
         result = subprocess.run(

--- a/linPEAS/tests/test_snap_confine.py
+++ b/linPEAS/tests/test_snap_confine.py
@@ -18,6 +18,7 @@ class SnapConfineCVE20268933Tests(unittest.TestCase):
             / "functions"
             / "checkSnapConfineCVE20268933.sh"
         )
+        cls.extract_version_helper = cls.function_file.parent / "lp_extract_upstream_version.sh"
 
     def _make_root(self, base, release="24.04", snap_version=None):
         root = base / "root"
@@ -81,6 +82,7 @@ class SnapConfineCVE20268933Tests(unittest.TestCase):
                 "SED_GREEN='&'",
                 'print_3title() { echo "TITLE: $1"; }',
                 "print_info() { :; }",
+                f". {shlex.quote(str(self.extract_version_helper))}",
                 f". {shlex.quote(str(self.function_file))}",
                 "checkSnapConfineCVE20268933",
             ]
@@ -125,7 +127,11 @@ class SnapConfineCVE20268933Tests(unittest.TestCase):
                 f"echo {version}=yes || echo {version}=no"
             )
         body = "\n".join(
-            [f". {shlex.quote(str(self.function_file))}"] + checks
+            [
+                f". {shlex.quote(str(self.extract_version_helper))}",
+                f". {shlex.quote(str(self.function_file))}",
+            ]
+            + checks
         )
         result = subprocess.run(
             ["sh", "-c", body],

--- a/linPEAS/tests/test_udisks.py
+++ b/linPEAS/tests/test_udisks.py
@@ -18,6 +18,8 @@ class UDisksCVE20267867Tests(unittest.TestCase):
             / "functions"
             / "checkUDisksCVE20267867.sh"
         )
+        cls.extract_version_helper = cls.function_file.parent / "lp_extract_upstream_version.sh"
+        cls.version_lt_helper = cls.function_file.parent / "lp_version_lt.sh"
 
     def _make_root(self, base, options="defaults,user"):
         root = base / "root"
@@ -92,6 +94,8 @@ class UDisksCVE20267867Tests(unittest.TestCase):
                 "SED_RED_YELLOW='&'",
                 'print_3title() { echo "TITLE: $1"; }',
                 "print_info() { :; }",
+                f". {shlex.quote(str(self.extract_version_helper))}",
+                f". {shlex.quote(str(self.version_lt_helper))}",
                 f". {shlex.quote(str(self.function_file))}",
                 "checkUDisksCVE20267867",
             ]
@@ -163,9 +167,9 @@ class UDisksCVE20267867Tests(unittest.TestCase):
     def test_version_comparison_handles_double_digit_components(self):
         body = "\n".join(
             [
-                f". {shlex.quote(str(self.function_file))}",
-                "ud7867_version_lt 2.10.91 2.11.2 && echo old=yes",
-                "ud7867_version_lt 2.11.10 2.11.2 || echo new=yes",
+                f". {shlex.quote(str(self.version_lt_helper))}",
+                "lp_version_lt 2.10.91 2.11.2 && echo old=yes",
+                "lp_version_lt 2.11.10 2.11.2 || echo new=yes",
             ]
         )
         result = subprocess.run(


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->\n<!-- daily-stats-summary: Simplified linpeas checks based on recent PEASS changes. -->\n\nAutomated simplifications for linpeas checks.\n\nAgent summary:\nPEASS linpeas autoimprover agent completed successfully with 24 steps. Agent Comment: Plan:
1. Map LinPEAS-only source/build/documentation locations and repository guidance.
2. Review the last 30 days of commits touching those locations.
3. Identify one small behavior-preserving deduplication, implement it, and update relevant documentation only if needed.
4. Run focused checks plus the required full LinPEAS build, then review the final diff.
Repository mapping is in progress. The worktree is clean, and the LinPEAS implementation is isolated under `linPEAS/` with shared generated-list input under `build_lists/`; I’ll now inspect only those LinPEAS-relevant paths and their recent history.
The recent-history review found a concrete low-risk target: three newly added CVE checks contain the exact same upstream-version extractor, and two also duplicate the same numeric dotted-version comparator. I’ll centralize only those identical helpers, leave each check’s detection/output logic untouched, and verify both standalone test harnesses and generated builds.
Implementation is complete: only the identical parsing/comparison routines were moved into two dependency-aware LinPEAS helper modules, and the three affected standalone test harnesses now source those helpers. Next I’m checking metadata resolution, focused behavior, helper inclusion in selective builds, and the final full build/diff.
Focused verification now passes: all 17 relevant tests succeed, selective generation includes each shared helper exactly once, and dependency ordering is correct. I’m proceeding with the required all-modules build, full LinPEAS test discovery, shell syntax validation, and a final cleanliness review.
## Summary

- Located LinPEAS implementation under:
  - `linPEAS/builder/linpeas_parts/`
  - `linPEAS/builder/`
  - `linPEAS/tests/`
- Reviewed seven LinPEAS commits from the last 30 days, including recent UDisks, needrestart, CIFSwitch, snap-confine, kernel registry, and doas changes.

## Refactor

Centralized duplicated version logic into:

- `functions/lp_extract_upstream_version.sh`
- `functions/lp_version_lt.sh`

These helpers are now shared by the UDisks, needrestart, and snap-confine CVE checks. Detection behavior and output remain unchanged. The generated script is 907 bytes smaller.

## Validation

- Full LinPEAS suite: **50 tests passed**
- Shell syntax validation: **passed**
- Full build: **passed**
  ```bash
  cd /tmp/peass-ng/linPEAS
  python3 -m builder.linpeas_builder --all --output /tmp/linpeas_fat.sh
  ```
- The command requires the documented `linPEAS/` working directory; invoking it directly from `/tmp/peass-ng` cannot locate the `builder` Python package.
- No README update was necessary because functionality, usage, and output format did not change.\n\nGenerated by PEASS autoimprover workflow.