### PR TITLE
autoimprover: simplify winpeas checks

### DIFF
--- a/winPEAS/winPEASexe/README.md
+++ b/winPEAS/winPEASexe/README.md
@@ -172,6 +172,7 @@ Once you have installed and activated it you need to:
   - [x] Interesting services (non Microsoft) information
   - [x] Modifiable services
   - [x] Writable service registry binpath
+  - [x] Writable DLLs loaded by enabled LocalSystem services
   - [x] PATH Dll Hijacking
 
 - **Applications Information**
@@ -180,6 +181,7 @@ Once you have installed and activated it you need to:
   - [x] Optional online installed-package vulnerability lookup via HackTricks (`-vulnpackages` or `all`)
   - [x] AutoRuns
   - [x] Scheduled tasks
+  - [x] Writable execution targets in enabled SYSTEM scheduled tasks
   - [x] Device drivers
 
 - **Network Information**
@@ -213,6 +215,7 @@ Once you have installed and activated it you need to:
   - [x] AppCmd.exe
   - [x] SSClient.exe
   - [x] SCCM
+  - [x] Cached SCCM Network Access Account credential policies
   - [x] Security Package Credentials
   - [x] AlwaysInstallElevated
   - [x] WSUS (HTTP downgrade + CVE-2025-59287 exposure)
@@ -236,6 +239,7 @@ Once you have installed and activated it you need to:
   - [x] Cloud credentials
   - [x] Check for unattended files
   - [x] Check for SAM & SYSTEM backups
+  - [x] Check for exposed SAM, SECURITY and SYSTEM hives in live ACLs, backups and shadow copies
   - [x] Check for cached GPP Passwords
   - [x] Check for and extract creds from McAffe SiteList.xml files
   - [x] Possible registries with credentials

--- a/winPEAS/winPEASexe/winPEAS/Helpers/PermissionsHelper.cs
+++ b/winPEAS/winPEASexe/winPEAS/Helpers/PermissionsHelper.cs
@@ -25,6 +25,65 @@ namespace winPEAS.Helpers
     /// Get interesting permissions from Files, Folders and Registry
     internal static class PermissionsHelper
     {
+        public static HashSet<string> GetUnprivilegedTokenSids()
+        {
+            bool isPrivilegedContext;
+            return GetUnprivilegedTokenSids(out isPrivilegedContext);
+        }
+
+        public static HashSet<string> GetUnprivilegedTokenSids(out bool isPrivilegedContext)
+        {
+            var unprivilegedSids = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "S-1-1-0",      // Everyone
+                "S-1-5-4",      // Interactive
+                "S-1-5-11",     // Authenticated Users
+                "S-1-5-32-545", // BUILTIN\Users
+            };
+
+            isPrivilegedContext = true;
+            try
+            {
+                using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
+                {
+                    var principal = new WindowsPrincipal(identity);
+                    var administratorsSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
+                    isPrivilegedContext = principal.IsInRole(administratorsSid) ||
+                        (identity.User != null && IsPrivilegedServiceSid(identity.User.Value));
+                    if (!isPrivilegedContext && identity.User != null)
+                    {
+                        unprivilegedSids.Add(identity.User.Value);
+                    }
+
+                    if (identity.Groups != null)
+                    {
+                        foreach (IdentityReference group in identity.Groups)
+                        {
+                            var sid = group as SecurityIdentifier;
+                            if (sid != null && principal.IsInRole(sid) && !sid.Equals(administratorsSid) &&
+                                !IsPrivilegedServiceSid(sid.Value))
+                            {
+                                unprivilegedSids.Add(sid.Value);
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Well-known low-privilege principals still provide useful configuration auditing.
+            }
+
+            return unprivilegedSids;
+        }
+
+        private static bool IsPrivilegedServiceSid(string sid)
+        {
+            return string.Equals(sid, "S-1-5-18", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(sid, "S-1-5-19", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(sid, "S-1-5-20", StringComparison.OrdinalIgnoreCase);
+        }
+
         public static List<string> GetPermissionsFile(string path, Dictionary<string, string> SIDs, PermissionType permissionType = PermissionType.DEFAULT)
         {
             /*Permisos especiales para carpetas 

--- a/winPEAS/winPEASexe/winPEAS/Info/ApplicationInfo/PrivilegedScheduledTasks.cs
+++ b/winPEAS/winPEASexe/winPEAS/Info/ApplicationInfo/PrivilegedScheduledTasks.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Security.AccessControl;
-using System.Security.Principal;
 using System.Text;
 using System.Text.RegularExpressions;
+using winPEAS.Helpers;
 using winPEAS.TaskScheduler;
 using ScheduledTask = winPEAS.TaskScheduler.Task;
 using TaskAction = winPEAS.TaskScheduler.Action;
@@ -91,7 +91,7 @@ namespace winPEAS.Info.ApplicationInfo
         public static PrivilegedScheduledTaskReport GetReport()
         {
             var report = new PrivilegedScheduledTaskReport();
-            HashSet<string> unprivilegedSids = GetUnprivilegedTokenSids();
+            HashSet<string> unprivilegedSids = PermissionsHelper.GetUnprivilegedTokenSids();
 
             try
             {
@@ -734,58 +734,6 @@ namespace winPEAS.Info.ApplicationInfo
             return binaryDescriptor == null || binaryDescriptor.Length == 0
                 ? null
                 : new RawSecurityDescriptor(binaryDescriptor, 0);
-        }
-
-        private static HashSet<string> GetUnprivilegedTokenSids()
-        {
-            var sids = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            {
-                "S-1-1-0",      // Everyone
-                "S-1-5-4",      // Interactive
-                "S-1-5-11",     // Authenticated Users
-                "S-1-5-32-545", // BUILTIN\Users
-            };
-
-            try
-            {
-                using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
-                {
-                    var principal = new WindowsPrincipal(identity);
-                    var administratorsSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
-                    bool privileged = principal.IsInRole(administratorsSid) ||
-                        (identity.User != null && IsPrivilegedServiceSid(identity.User.Value));
-                    if (!privileged && identity.User != null)
-                    {
-                        sids.Add(identity.User.Value);
-                    }
-
-                    if (identity.Groups != null)
-                    {
-                        foreach (IdentityReference group in identity.Groups)
-                        {
-                            var sid = group as SecurityIdentifier;
-                            if (sid != null && principal.IsInRole(sid) && !sid.Equals(administratorsSid) &&
-                                !IsPrivilegedServiceSid(sid.Value))
-                            {
-                                sids.Add(sid.Value);
-                            }
-                        }
-                    }
-                }
-            }
-            catch
-            {
-                // Well-known low-privilege principals still provide useful configuration auditing.
-            }
-
-            return sids;
-        }
-
-        private static bool IsPrivilegedServiceSid(string sid)
-        {
-            return string.Equals(sid, "S-1-5-18", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(sid, "S-1-5-19", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(sid, "S-1-5-20", StringComparison.OrdinalIgnoreCase);
         }
 
         private static string GetAccessPath(string displayPath)

--- a/winPEAS/winPEASexe/winPEAS/Info/FilesInfo/RegistryHiveExposure.cs
+++ b/winPEAS/winPEASexe/winPEAS/Info/FilesInfo/RegistryHiveExposure.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Management;
 using System.Security.AccessControl;
-using System.Security.Principal;
+using winPEAS.Helpers;
 using winPEAS.Native;
 
 namespace winPEAS.Info.FilesInfo
@@ -55,7 +55,7 @@ namespace winPEAS.Info.FilesInfo
             }
 
             bool isPrivilegedContext;
-            HashSet<string> unprivilegedSids = GetUnprivilegedTokenSids(out isPrivilegedContext);
+            HashSet<string> unprivilegedSids = PermissionsHelper.GetUnprivilegedTokenSids(out isPrivilegedContext);
             CheckLiveHiveAcls(systemRoot, unprivilegedSids, report);
             CheckBackupHives(backupPaths, unprivilegedSids, isPrivilegedContext, report);
             CheckShadowCopies(systemRoot, unprivilegedSids, isPrivilegedContext, report);
@@ -282,58 +282,6 @@ namespace winPEAS.Info.FilesInfo
             {
                 return null;
             }
-        }
-
-        private static HashSet<string> GetUnprivilegedTokenSids(out bool isPrivilegedContext)
-        {
-            var unprivilegedSids = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            {
-                "S-1-1-0",      // Everyone
-                "S-1-5-4",      // Interactive
-                "S-1-5-11",     // Authenticated Users
-                "S-1-5-32-545", // BUILTIN\Users (the vulnerable CVE-2021-36934 ACE)
-            };
-            isPrivilegedContext = true;
-            try
-            {
-                using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
-                {
-                    var principal = new WindowsPrincipal(identity);
-                    var administratorsSid = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);
-                    isPrivilegedContext = principal.IsInRole(administratorsSid) ||
-                        (identity.User != null && IsPrivilegedServiceSid(identity.User.Value));
-                    if (!isPrivilegedContext && identity.User != null)
-                    {
-                        unprivilegedSids.Add(identity.User.Value);
-                    }
-
-                    if (identity.Groups != null)
-                    {
-                        foreach (IdentityReference group in identity.Groups)
-                        {
-                            var sid = group as SecurityIdentifier;
-                            if (sid != null && principal.IsInRole(sid) && !IsPrivilegedServiceSid(sid.Value) &&
-                                !sid.Equals(administratorsSid))
-                            {
-                                unprivilegedSids.Add(sid.Value);
-                            }
-                        }
-                    }
-                }
-            }
-            catch
-            {
-                // Keep the well-known unprivileged principals and avoid current-token open tests.
-            }
-
-            return unprivilegedSids;
-        }
-
-        private static bool IsPrivilegedServiceSid(string sid)
-        {
-            return string.Equals(sid, "S-1-5-18", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(sid, "S-1-5-19", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(sid, "S-1-5-20", StringComparison.OrdinalIgnoreCase);
         }
 
         internal static string FindReadTrustee(RawSecurityDescriptor descriptor, ISet<string> enabledSids)


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->\n<!-- daily-stats-summary: Simplified winpeas checks based on recent PEASS changes. -->\n\nAutomated simplifications for winpeas checks.\n\nAgent summary:\nPEASS winpeas autoimprover agent completed successfully with 39 steps. Agent Comment: I’ll first map only the WinPEAS C# project and its repository guidance, then inspect the last 30 days of relevant history. I’ll identify one small, behavior-preserving deduplication, implement it, and verify it with the project’s available build/tests plus a focused diff review.
Plan status: repository mapping is complete. I found the C# solution under `winPEAS/winPEASexe`; the worktree is clean and there are no local repository instruction files. Next I’m narrowing recent history and the check/helper layout before choosing a refactor.
Recent-history review is complete: four WinPEAS C# commits fall in the window, each adding a focused check (registry hive exposure, SCCM NAA credentials, privileged scheduled tasks, and writable service DLLs). I’m now comparing those additions against existing helpers, concentrating on repeated ACL/path handling where consolidation can be kept local and output-neutral.
Refactor choice: centralize the nearly identical current-token SID filtering used by the new registry-hive and privileged-scheduled-task checks into the existing `PermissionsHelper`. This removes two copies of Windows identity/group enumeration without changing either check’s ACL evaluation, safety limits, findings, or printed text. I’ll also add the four recent checks to the existing README checklist, which is currently behind the implementation.
The focused diff is clean and now removes 102 duplicated lines while adding one shared 59-line implementation. The behavior-sensitive distinction is preserved: callers that need to know whether token inspection failed still receive `isPrivilegedContext = true`, while both checks retain the same fallback SID set. Next I’m validating project references, syntax/build availability, tests, and final output-facing changes.
Validation so far: package restore succeeded; the extracted shared helper compiles and its baseline-SID/overload smoke test passes. The legacy Mono `xbuild` cannot compile the repository’s existing C# 8 constructs, so I’m making one final build attempt with a modern Roslyn compiler rather than treating those unrelated parser errors as a code failure.
The modern-compiler attempt progressed past all C# 8 parser issues but is blocked by a Mono/Windows code-page P/Invoke failure while opening pre-existing AlphaFS sources; no changed file appears in the build errors. I’m completing a final worktree/diff audit now and will report the successful focused compilation/smoke test separately from that environment limitation.
## Summary

- Located WinPEAS C# under `winPEAS/winPEASexe/`:
  - Check orchestration: `winPEAS/Checks/`
  - Implementations: `winPEAS/Info/`
  - Shared utilities: `winPEAS/Helpers/`
  - Tests: `Tests/`

- Reviewed four commits from the last 30 days:
  - `78f1f3f` — writable LocalSystem service DLL detection
  - `b7691e4` — privileged scheduled-task detection
  - `7aca47a` — SCCM Network Access Account detection
  - `b930326` — registry-hive exposure detection

## Refactoring

- Moved duplicated current-token SID enumeration and privileged-service SID filtering into:
  - `winPEAS/Helpers/PermissionsHelper.cs`
- Updated these checks to use the shared helper:
  - `Info/ApplicationInfo/PrivilegedScheduledTasks.cs`
  - `Info/FilesInfo/RegistryHiveExposure.cs`
- Net reduction: **41 lines**.
- Preserved fallback behavior, privilege-context handling, ACL logic, safety limits, and all output text.

## Documentation

Updated `winPEAS/winPEASexe/README.md` with the four recently added checks.

## Validation

- `git diff --check`: passed.
- Project XML validation: passed.
- Shared helper compilation: passed.
- Baseline SID and overload smoke test: passed.
- NuGet restore: passed.
- Full solution build could not complete on Linux/Mono because Roslyn encountered a Windows code-page P/Invoke failure while opening existing bundled AlphaFS sources. No changed file appeared in build errors.

The LinPEAS build was not run because the target tool is WinPEAS.\n\nGenerated by PEASS autoimprover workflow.