### PR TITLE
new-check(linpeas): add high-impact vulnerability detection

### DIFF
--- a/linPEAS/builder/linpeas_parts/1_system_information/7_Mounts.sh
+++ b/linPEAS/builder/linpeas_parts/1_system_information/7_Mounts.sh
@@ -1,8 +1,8 @@
 # Title: System Information - Mounts
 # ID: SY_Mounts
 # Author: Carlos Polop
-# Last Update: 07-03-2024
-# Description: Check for mount point misconfigurations that could lead to privilege escalation and udisks2 CVE-2026-7867 exposure:
+# Last Update: 07-09-2026
+# Description: Check for mount point misconfigurations that could lead to privilege escalation, udisks2 CVE-2026-7867 exposure, and XFSTango CVE-2026-80530 exposure:
 #   - Unmounted filesystems
 #   - Mount point permissions
 #   - Mount options
@@ -24,9 +24,9 @@
 #       - Mount option exploitation
 #       - Shared mount abuse
 # License: GNU GPL
-# Version: 1.1
+# Version: 1.2
 # Mitre: T1068,T1082,T1120
-# Functions Used: checkUDisksCVE20267867, print_2title, print_info
+# Functions Used: checkUDisksCVE20267867, checkXFSTangoCVE202680530, print_2title, print_info
 # Global Variables: $DEBUG, $SEARCH_IN_FOLDER, $mountG, $mountpermsB, $mountpermsG, $notmounted, $Wfolders, $mounted
 # Initial Functions:
 # Generated Global Variables:
@@ -36,6 +36,7 @@
 
 if ! [ "$SEARCH_IN_FOLDER" ]; then
     checkUDisksCVE20267867
+    checkXFSTangoCVE202680530
 fi
 
 if [ -f "/etc/fstab" ] || [ "$DEBUG" ]; then

--- a/linPEAS/builder/linpeas_parts/functions/checkXFSTangoCVE202680530.sh
+++ b/linPEAS/builder/linpeas_parts/functions/checkXFSTangoCVE202680530.sh
@@ -1,0 +1,163 @@
+# Title: Functions - checkXFSTangoCVE202680530
+# ID: checkXFSTangoCVE202680530
+# Author: Chack Agent
+# Last Update: 07-09-2026
+# Description: Passively identify mounted XFS filesystems exposed to the XFSTango reflink local privilege-escalation condition (CVE-2026-80530).
+# License: GNU GPL
+# Version: 1.0
+# Mitre: T1068
+# Functions Used: print_3title, print_info
+# Global Variables: $E, $SED_GREEN, $SED_LIGHT_CYAN, $SED_RED_YELLOW, $SED_YELLOW, $TIMEOUT
+# Initial Functions:
+# Generated Global Variables: $xft80530_distro_id, $xft80530_distro_version, $xft80530_info, $xft80530_kernel, $xft80530_mount_file, $xft80530_mountpoint, $xft80530_mountpoint_escaped, $xft80530_mounts, $xft80530_os_release, $xft80530_rc, $xft80530_reflink_enabled, $xft80530_reflink_status, $xft80530_reflink_unknown, $xft80530_status, $xft80530_version
+# Fat linpeas: 0
+# Small linpeas: 1
+
+
+xft80530_version_lt() {
+  [ -n "$1" ] && [ -n "$2" ] || return 1
+  awk -v xft80530_a="$1" -v xft80530_b="$2" 'BEGIN {
+    xft80530_na = split(xft80530_a, xft80530_av, ".")
+    xft80530_nb = split(xft80530_b, xft80530_bv, ".")
+    xft80530_n = xft80530_na > xft80530_nb ? xft80530_na : xft80530_nb
+    for (xft80530_i = 1; xft80530_i <= xft80530_n; xft80530_i++) {
+      xft80530_ai = xft80530_av[xft80530_i] + 0
+      xft80530_bi = xft80530_bv[xft80530_i] + 0
+      if (xft80530_ai < xft80530_bi) exit 0
+      if (xft80530_ai > xft80530_bi) exit 1
+    }
+    exit 1
+  }'
+}
+
+xft80530_kernel_status() {
+  case "$1" in
+    7.2.0-rc*)
+      xft80530_rc="$(printf '%s' "$1" | sed -nE 's/^7\.2\.0-rc([0-9]+).*/\1/p')"
+      if [ -n "$xft80530_rc" ] && [ "$xft80530_rc" -ge 7 ]; then
+        echo "fixed"
+      else
+        echo "affected"
+      fi
+      return
+      ;;
+  esac
+  xft80530_version="$(printf '%s' "$1" | sed -nE 's/^([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')"
+  if [ -z "$xft80530_version" ]; then
+    echo "unknown"
+  elif xft80530_version_lt "$xft80530_version" "6.10.0"; then
+    echo "predates"
+  elif ! xft80530_version_lt "$xft80530_version" "7.2.0"; then
+    echo "fixed"
+  else
+    case "$xft80530_version" in
+      6.12.*)
+        if ! xft80530_version_lt "$xft80530_version" "6.12.105"; then
+          echo "fixed"
+        else
+          echo "affected"
+        fi
+        ;;
+      6.18.*)
+        if ! xft80530_version_lt "$xft80530_version" "6.18.46"; then
+          echo "fixed"
+        else
+          echo "affected"
+        fi
+        ;;
+      7.1.*)
+        if ! xft80530_version_lt "$xft80530_version" "7.1.10"; then
+          echo "fixed"
+        else
+          echo "affected"
+        fi
+        ;;
+      *) echo "affected" ;;
+    esac
+  fi
+}
+
+checkXFSTangoCVE202680530() {
+  [ "$(uname -s 2>/dev/null)" = "Linux" ] || return 0
+
+  xft80530_kernel="${1:-$(uname -r 2>/dev/null)}"
+  xft80530_mount_file="${2:-/proc/self/mounts}"
+  xft80530_os_release="${3:-/etc/os-release}"
+  [ -r "$xft80530_mount_file" ] || return 0
+
+  # Limit filesystem queries on hosts with very large mount namespaces.
+  xft80530_mounts="$(awk '$3 == "xfs" { print $2 }' "$xft80530_mount_file" 2>/dev/null | head -n 20)"
+  [ -n "$xft80530_mounts" ] || return 0
+
+  xft80530_status="$(xft80530_kernel_status "$xft80530_kernel")"
+  xft80530_distro_id="$(sed -nE 's/^ID="?([^" ]+)"?$/\1/p' "$xft80530_os_release" 2>/dev/null | head -n1)"
+  xft80530_distro_version="$(sed -nE 's/^VERSION_ID="?([^" ]+)"?$/\1/p' "$xft80530_os_release" 2>/dev/null | head -n1)"
+  # Red Hat confirms that its 5.14-based RHEL 9 kernel backported the
+  # vulnerable code, while RHEL 10 did not.  Do not trust upstream version
+  # boundaries alone for these vendor kernels.
+  case "$xft80530_distro_id:$xft80530_distro_version" in
+    rhel:9*|centos:9*|rocky:9*|almalinux:9*) xft80530_status="vendor_affected" ;;
+    rhel:10*) xft80530_status="vendor_unaffected" ;;
+  esac
+  xft80530_reflink_enabled=0
+  xft80530_reflink_unknown=0
+
+  print_3title "XFSTango XFS reflink LPE (CVE-2026-80530)" "T1068"
+  print_info "https://seclists.org/oss-sec/2026/q3/641"
+  echo "Kernel: $xft80530_kernel" | sed -${E} "s,.*,${SED_LIGHT_CYAN},"
+  echo "Mounted XFS filesystems (maximum 20):"
+
+  while IFS= read -r xft80530_mountpoint_escaped; do
+    [ -n "$xft80530_mountpoint_escaped" ] || continue
+    # /proc/self/mounts represents whitespace as octal escapes.
+    xft80530_mountpoint="$(printf '%b' "$xft80530_mountpoint_escaped")"
+    xft80530_info=""
+    if [ -n "$TIMEOUT" ] && command -v xfs_info >/dev/null 2>&1; then
+      xft80530_info="$("$TIMEOUT" 2 xfs_info "$xft80530_mountpoint" 2>/dev/null)"
+    fi
+
+    if printf '%s\n' "$xft80530_info" | grep -Eq '(^|[[:space:]])reflink=1([[:space:]]|$)'; then
+      xft80530_reflink_status="enabled"
+      xft80530_reflink_enabled=$((xft80530_reflink_enabled + 1))
+    elif printf '%s\n' "$xft80530_info" | grep -Eq '(^|[[:space:]])reflink=0([[:space:]]|$)'; then
+      xft80530_reflink_status="disabled"
+    else
+      xft80530_reflink_status="unknown (xfs_info unavailable or inconclusive)"
+      xft80530_reflink_unknown=$((xft80530_reflink_unknown + 1))
+    fi
+    printf '  %s - reflink %s\n' "$xft80530_mountpoint" "$xft80530_reflink_status"
+  done <<EOF
+$xft80530_mounts
+EOF
+
+  case "$xft80530_status" in
+    predates)
+      echo "NOT VULNERABLE: upstream kernel $xft80530_kernel predates the vulnerable code introduced in 6.10" | sed -${E} "s,.*,${SED_GREEN},"
+      ;;
+    fixed)
+      echo "NOT VULNERABLE by upstream version: kernel $xft80530_kernel is at or after a known fixed release" | sed -${E} "s,.*,${SED_GREEN},"
+      ;;
+    vendor_unaffected)
+      echo "NOT VULNERABLE according to the Red Hat advisory: this RHEL 10-family kernel did not include the vulnerable code" | sed -${E} "s,.*,${SED_GREEN},"
+      ;;
+    affected|vendor_affected)
+      if [ "$xft80530_reflink_enabled" -gt 0 ]; then
+        if [ "$xft80530_status" = "vendor_affected" ]; then
+          echo "POTENTIALLY VULNERABLE to CVE-2026-80530: this is a RHEL 9-family kernel (Red Hat lists RHEL 9 affected despite its 5.14 base), and XFS reflink is enabled" | sed -${E} "s,.*,${SED_RED_YELLOW},"
+        else
+          echo "POTENTIALLY VULNERABLE to CVE-2026-80530: affected upstream kernel range and an XFS filesystem with reflink enabled" | sed -${E} "s,.*,${SED_RED_YELLOW},"
+        fi
+        echo "Exploitation also requires an attacker-writable location and a readable target on the same XFS filesystem"
+        echo "Vendor kernels may contain a backported fix; verify the installed kernel package advisory" | sed -${E} "s,.*,${SED_YELLOW},"
+      elif [ "$xft80530_reflink_unknown" -gt 0 ]; then
+        echo "POTENTIALLY VULNERABLE to CVE-2026-80530: affected upstream kernel range; confirm whether reflink is enabled on the XFS filesystem(s)" | sed -${E} "s,.*,${SED_YELLOW},"
+      else
+        echo "Mitigated: the mounted XFS filesystem(s) report reflink disabled" | sed -${E} "s,.*,${SED_GREEN},"
+      fi
+      ;;
+    *)
+      echo "XFS is mounted, but kernel version could not be assessed for CVE-2026-80530" | sed -${E} "s,.*,${SED_YELLOW},"
+      ;;
+  esac
+  echo ""
+}

--- a/linPEAS/tests/test_xfstango.py
+++ b/linPEAS/tests/test_xfstango.py
@@ -1,0 +1,185 @@
+import os
+import shlex
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class XFSTangoCVE202680530Tests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.repo_root = Path(__file__).resolve().parents[2]
+        cls.function_file = (
+            cls.repo_root
+            / "linPEAS"
+            / "builder"
+            / "linpeas_parts"
+            / "functions"
+            / "checkXFSTangoCVE202680530.sh"
+        )
+
+    def _run_check(
+        self,
+        kernel,
+        filesystem="xfs",
+        reflink="1",
+        with_xfs_info=True,
+        distro_id="ubuntu",
+        distro_version="26.04",
+    ):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            mounts = base / "mounts"
+            mounts.write_text(
+                f"/dev/test /srv/test {filesystem} rw,relatime 0 0\n",
+                encoding="utf-8",
+            )
+            os_release = base / "os-release"
+            os_release.write_text(
+                f"ID={distro_id}\nVERSION_ID=\"{distro_version}\"\n",
+                encoding="utf-8",
+            )
+            bindir = base / "bin"
+            bindir.mkdir()
+            timeout = bindir / "timeout"
+            timeout.write_text('#!/bin/sh\nshift\nexec "$@"\n', encoding="utf-8")
+            timeout.chmod(0o755)
+            marker = base / "xfs_info_args"
+            if with_xfs_info:
+                xfs_info = bindir / "xfs_info"
+                xfs_info.write_text(
+                    "#!/bin/sh\n"
+                    'printf "%s\\n" "$*" > "$XFS_INFO_MARKER"\n'
+                    'printf "data = bsize=4096 reflink=%s bigtime=1\\n" "$FAKE_REFLINK"\n',
+                    encoding="utf-8",
+                )
+                xfs_info.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "FAKE_REFLINK": reflink,
+                    "PATH": f"{bindir}:{env['PATH']}",
+                    "XFS_INFO_MARKER": str(marker),
+                }
+            )
+            body = "\n".join(
+                [
+                    "E=E",
+                    f"TIMEOUT={shlex.quote(str(timeout))}",
+                    "SED_GREEN='&'",
+                    "SED_LIGHT_CYAN='&'",
+                    "SED_RED_YELLOW='&'",
+                    "SED_YELLOW='&'",
+                    'print_3title() { echo "TITLE: $1"; }',
+                    "print_info() { :; }",
+                    f". {shlex.quote(str(self.function_file))}",
+                    "checkXFSTangoCVE202680530 "
+                    f"{shlex.quote(kernel)} {shlex.quote(str(mounts))} "
+                    f"{shlex.quote(str(os_release))}",
+                ]
+            )
+            result = subprocess.run(
+                ["sh", "-c", body],
+                cwd=str(self.repo_root),
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            marker_value = marker.read_text(encoding="utf-8").strip() if marker.exists() else ""
+        return result, marker_value
+
+    def test_affected_kernel_and_reflink_filesystem_are_reported(self):
+        result, marker = self._run_check("6.12.104-custom")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("TITLE: XFSTango XFS reflink LPE", result.stdout)
+        self.assertIn("POTENTIALLY VULNERABLE to CVE-2026-80530", result.stdout)
+        self.assertIn("/srv/test - reflink enabled", result.stdout)
+        self.assertEqual("/srv/test", marker)
+
+    def test_fixed_stable_kernel_is_not_reported_as_vulnerable(self):
+        result, _ = self._run_check("6.12.105")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("NOT VULNERABLE by upstream version", result.stdout)
+        self.assertNotIn("POTENTIALLY VULNERABLE", result.stdout)
+
+    def test_reflink_disabled_is_reported_as_mitigated(self):
+        result, _ = self._run_check("7.1.9", reflink="0")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Mitigated: the mounted XFS filesystem(s) report reflink disabled", result.stdout)
+        self.assertNotIn("POTENTIALLY VULNERABLE", result.stdout)
+
+    def test_unknown_reflink_state_preserves_a_cautious_warning(self):
+        result, marker = self._run_check("6.18.45", with_xfs_info=False)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("confirm whether reflink is enabled", result.stdout)
+        self.assertEqual("", marker)
+
+    def test_rhel9_backport_is_not_missed_by_upstream_version_gate(self):
+        result, _ = self._run_check(
+            "5.14.0-570.el9_6.x86_64", distro_id="rhel", distro_version="9.6"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("POTENTIALLY VULNERABLE to CVE-2026-80530", result.stdout)
+        self.assertIn("Red Hat lists RHEL 9 affected despite its 5.14 base", result.stdout)
+
+    def test_rhel10_vendor_status_overrides_upstream_range(self):
+        result, _ = self._run_check(
+            "6.12.0-55.el10.x86_64", distro_id="rhel", distro_version="10.0"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("NOT VULNERABLE according to the Red Hat advisory", result.stdout)
+        self.assertNotIn("POTENTIALLY VULNERABLE", result.stdout)
+
+    def test_non_xfs_mount_is_suppressed(self):
+        result, marker = self._run_check("6.12.104", filesystem="ext4")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual("", result.stdout)
+        self.assertEqual("", marker)
+
+    def test_upstream_version_boundaries(self):
+        cases = {
+            "6.9.12": "predates",
+            "6.10.0": "affected",
+            "6.12.104": "affected",
+            "6.12.105": "fixed",
+            "6.18.45": "affected",
+            "6.18.46": "fixed",
+            "7.0.9": "affected",
+            "7.1.9": "affected",
+            "7.1.10": "fixed",
+            "7.2.0-rc6": "affected",
+            "7.2.0-rc7": "fixed",
+            "7.2.0": "fixed",
+        }
+        checks = [
+            f"echo {version}=$(xft80530_kernel_status {shlex.quote(version)})"
+            for version in cases
+        ]
+        body = "\n".join(
+            [f". {shlex.quote(str(self.function_file))}"] + checks
+        )
+        result = subprocess.run(
+            ["sh", "-c", body],
+            cwd=str(self.repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for version, status in cases.items():
+            self.assertIn(f"{version}={status}", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->

<!-- daily-stats-summary: Proposed one high-impact linpeas vulnerability check. -->

Automated proposal for one new, high-impact `linpeas` vulnerability-detection check.

Agent research and validation summary:
PEASS linpeas new-check agent completed successfully with 57 steps. Agent Comment: Implemented exactly one new passive linPEAS check: **XFSTango / CVE-2026-80530**.

### Why selected

- High-severity local XFS flaw allowing an unprivileged user to bypass reflink Copy-on-Write protections and potentially modify privileged files.
- Affects upstream kernels from 6.10, with fixes in 6.12.105, 6.18.46, 7.1.10, and 7.2-rc7.
- Red Hat rates it **Important** and lists RHEL 9 as affected despite its 5.14-based kernel because the vulnerable code was backported.
- XFS is common on enterprise Linux systems.

### Detection

The bounded, read-only check:

- Enumerates at most 20 mounted XFS filesystems from `/proc/self/mounts`.
- Uses `xfs_info` under a two-second timeout to determine whether reflink is enabled.
- Evaluates upstream fixed-version boundaries, including 7.2 release candidates.
- Handles RHEL 9’s vulnerable backport and RHEL 10’s vendor-not-affected status.
- Reports cautious “potentially vulnerable” results for vendor kernels where backports cannot be established conclusively.
- Does not create files, exercise ioctls, or expose file contents.

### Files changed

- `linPEAS/builder/linpeas_parts/functions/checkXFSTangoCVE202680530.sh`
- `linPEAS/builder/linpeas_parts/1_system_information/7_Mounts.sh`
- `linPEAS/tests/test_xfstango.py`

### Validation

- Modified shell files passed `sh -n`.
- `python3 -m unittest linPEAS.tests.test_modules_metadata`: **8 passed**
- `python3 -m unittest discover -s linPEAS/tests -p "test_*.py"`: **58 passed**
- Builder completed to `/tmp/linpeas_new_check.sh`.
- Generated script passed `sh -n`.
- Verified exactly one generated function definition and one call site.
- `git diff --check` passed.

The environment lacked an XFS mount and XFS utilities, so validation used deterministic passive fixtures rather than attempting exploitation or filesystem mutation.

### Sources

- [Official CVE record](https://www.cve.org/CVERecord?id=CVE-2026-80530)
- [Upstream Linux fix](https://git.kernel.org/linus/b2d5a81dae385333f9734910277fbf94c78bd17f)
- [Red Hat advisory](https://access.redhat.com/security/cve/cve-2026-80530)
- [Ubuntu advisory](https://ubuntu.com/security/CVE-2026-80530)
- [Original oss-security disclosure](https://seclists.org/oss-sec/2026/q3/641)

Generated by the PEASS New Vulnerability Checks workflow. This PR must pass PEASS PR-tests and normal Chack-Agent review.
