### PR TITLE
new-check(winpeas): add high-impact vulnerability detection

### DIFF
--- a/winPEAS/winPEASexe/Tests/WritableServiceRecoveryCommandTests.cs
+++ b/winPEAS/winPEASexe/Tests/WritableServiceRecoveryCommandTests.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using winPEAS.Info.ServicesInfo;
+
+namespace Tests
+{
+    [TestClass]
+    public class WritableServiceRecoveryCommandTests
+    {
+        [TestMethod]
+        public void EligibilityRequiresEnabledUnprotectedLocalSystemWin32Service()
+        {
+            Assert.IsTrue(ServicesInfoHelper.IsEligibleRecoveryService(0x10, 2, 0, "LocalSystem"));
+            Assert.IsTrue(ServicesInfoHelper.IsEligibleRecoveryService(0x20, 3, null, string.Empty));
+
+            Assert.IsFalse(ServicesInfoHelper.IsEligibleRecoveryService(0x1, 2, 0, "LocalSystem"));
+            Assert.IsFalse(ServicesInfoHelper.IsEligibleRecoveryService(0x10, 4, 0, "LocalSystem"));
+            Assert.IsFalse(ServicesInfoHelper.IsEligibleRecoveryService(0x10, 2, 1, "LocalSystem"));
+            Assert.IsFalse(ServicesInfoHelper.IsEligibleRecoveryService(
+                0x10,
+                2,
+                0,
+                @"NT AUTHORITY\LocalService"));
+        }
+
+        [TestMethod]
+        public void ParsesQuotedExpandedAndUnquotedRecoveryExecutables()
+        {
+            string executable;
+            string arguments;
+
+            Assert.IsTrue(ServicesInfoHelper.TryParseRecoveryCommand(
+                @"""%SystemRoot%\System32\cmd.exe"" /c C:\ProgramData\Vendor\recover.cmd",
+                @"C:\Windows",
+                out executable,
+                out arguments));
+            Assert.AreEqual(@"C:\Windows\System32\cmd.exe", executable);
+            Assert.AreEqual(@"/c C:\ProgramData\Vendor\recover.cmd", arguments);
+
+            Assert.IsTrue(ServicesInfoHelper.TryParseRecoveryCommand(
+                @"C:\Program Files\Vendor\recovery.exe --quiet",
+                @"C:\Windows",
+                out executable,
+                out arguments));
+            Assert.AreEqual(@"C:\Program Files\Vendor\recovery.exe", executable);
+            Assert.AreEqual("--quiet", arguments);
+
+            Assert.IsTrue(ServicesInfoHelper.TryParseRecoveryCommand(
+                @"cmd /c C:\ProgramData\Vendor\helper.exe",
+                @"C:\Windows",
+                out executable,
+                out arguments));
+            Assert.AreEqual(@"C:\Windows\System32\cmd.exe", executable);
+            Assert.AreEqual(@"/c C:\ProgramData\Vendor\helper.exe", arguments);
+        }
+
+        [TestMethod]
+        public void ResolvesKnownInterpreterAndReferencedScriptTargets()
+        {
+            var targets = ServicesInfoHelper.GetRecoveryCommandTargets(
+                @"cmd.exe /c C:\ProgramData\Vendor\recover.cmd",
+                @"C:\Windows");
+
+            CollectionAssert.Contains(targets, @"C:\Windows\System32\cmd.exe");
+            CollectionAssert.Contains(targets, @"C:\ProgramData\Vendor\recover.cmd");
+            Assert.AreEqual(2, targets.Distinct(System.StringComparer.OrdinalIgnoreCase).Count());
+        }
+
+        [TestMethod]
+        public void RejectsRemoteUnexpandedAndMalformedCommands()
+        {
+            string executable;
+            string arguments;
+
+            Assert.IsFalse(ServicesInfoHelper.TryParseRecoveryCommand(
+                @"\\server\share\recover.exe",
+                @"C:\Windows",
+                out executable,
+                out arguments));
+            Assert.IsFalse(ServicesInfoHelper.TryParseRecoveryCommand(
+                @"%UNKNOWN_RECOVERY_ROOT%\recover.exe",
+                @"C:\Windows",
+                out executable,
+                out arguments));
+            Assert.IsFalse(ServicesInfoHelper.TryParseRecoveryCommand(
+                @"""C:\Program Files\Vendor\recovery.exe --quiet",
+                @"C:\Windows",
+                out executable,
+                out arguments));
+        }
+    }
+}

--- a/winPEAS/winPEASexe/Tests/winPEAS.Tests.csproj
+++ b/winPEAS/winPEASexe/Tests/winPEAS.Tests.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SmokeTests.cs" />
     <Compile Include="WritableServiceDllTests.cs" />
+    <Compile Include="WritableServiceRecoveryCommandTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/winPEAS/winPEASexe/winPEAS/Checks/ServicesInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/ServicesInfo.cs
@@ -38,6 +38,7 @@ namespace winPEAS.Checks
                 PrintModifiableServices,
                 PrintWritableRegServices,
                 PrintWritableSystemServiceDlls,
+                PrintWritableSystemRecoveryCommands,
                 PrintPathDllHijacking,
                 PrintOemPrivilegedUtilities,
                 PrintLegacySignedKernelDrivers,
@@ -220,6 +221,50 @@ namespace winPEAS.Checks
                 if (report.FindingLimitReached)
                 {
                     Beaprint.GrayPrint($"    Findings were capped at {ServicesInfoHelper.MaxServiceDllFindings}.");
+                }
+            }
+            catch (Exception ex)
+            {
+                Beaprint.PrintException(ex.Message);
+            }
+        }
+
+        void PrintWritableSystemRecoveryCommands()
+        {
+            try
+            {
+                Beaprint.MainPrint("Writable LocalSystem service recovery command targets", "T1543.003");
+                Beaprint.LinkPrint(
+                    "https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_failure_actionsw",
+                    "A replaceable target used by an SC_ACTION_RUN_COMMAND recovery action executes under the service account when recovery fires.");
+
+                WritableServiceRecoveryCommandReport report =
+                    ServicesInfoHelper.GetWritableSystemRecoveryCommands(Checks.CurrentUserSiDs);
+                if (report.Findings.Count == 0)
+                {
+                    Beaprint.GoodPrint($"    No replaceable recovery command targets found in {report.ServicesInspected} inspected service(s).");
+                }
+
+                foreach (WritableServiceRecoveryCommandInfo finding in report.Findings)
+                {
+                    Beaprint.BadPrint($"    {finding.ServiceName} ({finding.Account})");
+                    Beaprint.NoColorPrint($"      Target exists : {finding.TargetExists}");
+                    Beaprint.NoColorPrint($"      Target path   : {finding.TargetPath}");
+                    Beaprint.BadPrint($"      Evidence      : {finding.AccessReason}");
+                    Beaprint.PrintLineSeparator();
+                }
+
+                if (report.Findings.Count > 0)
+                {
+                    Beaprint.GrayPrint("    Recovery actions run only after a qualifying service failure; this check does not stop, start, or crash services.");
+                }
+                if (report.ServiceLimitReached)
+                {
+                    Beaprint.GrayPrint($"    Service inspection stopped at the safety limit of {ServicesInfoHelper.MaxRecoveryCommandServices}.");
+                }
+                if (report.FindingLimitReached)
+                {
+                    Beaprint.GrayPrint($"    Findings were capped at {ServicesInfoHelper.MaxRecoveryCommandFindings}.");
                 }
             }
             catch (Exception ex)

--- a/winPEAS/winPEASexe/winPEAS/Info/ServicesInfo/ServicesInfoHelper.cs
+++ b/winPEAS/winPEASexe/winPEAS/Info/ServicesInfo/ServicesInfoHelper.cs
@@ -15,6 +15,7 @@ using System.ServiceProcess;
 using System.Text.RegularExpressions;
 using winPEAS.Helpers;
 using winPEAS.Helpers.Registry;
+using winPEAS.Info.ApplicationInfo;
 using winPEAS.Native;
 
 namespace winPEAS.Info.ServicesInfo
@@ -36,14 +37,40 @@ namespace winPEAS.Info.ServicesInfo
         public bool FindingLimitReached { get; set; }
     }
 
+    internal sealed class WritableServiceRecoveryCommandInfo
+    {
+        public string ServiceName { get; set; }
+        public string Account { get; set; }
+        public string TargetPath { get; set; }
+        public bool TargetExists { get; set; }
+        public string AccessReason { get; set; }
+    }
+
+    internal sealed class WritableServiceRecoveryCommandReport
+    {
+        public List<WritableServiceRecoveryCommandInfo> Findings { get; } = new List<WritableServiceRecoveryCommandInfo>();
+        public int ServicesInspected { get; set; }
+        public bool ServiceLimitReached { get; set; }
+        public bool FindingLimitReached { get; set; }
+    }
+
     class ServicesInfoHelper
     {
         internal const int MaxServiceDllServices = 4096;
         internal const int MaxServiceDllFindings = 64;
+        internal const int MaxRecoveryCommandServices = 4096;
+        internal const int MaxRecoveryCommandFindings = 64;
 
+        private const int ServiceWin32OwnProcess = 0x10;
         private const int ServiceWin32ShareProcess = 0x20;
         private const int ServiceWin32TypeMask = 0x30;
         private const int ServiceDisabled = 0x4;
+        private const uint ScManagerConnect = 0x0001;
+        private const uint ServiceQueryConfig = 0x0001;
+        private const uint ServiceConfigFailureActions = 2;
+        private const int ScActionRunCommand = 3;
+        private const uint ErrorInsufficientBuffer = 122;
+        private const uint MaxServiceConfigBuffer = 8192;
         private const int FileWriteData = 0x00000002;
         private const int FileAddFile = 0x00000002;
         private const int FileDeleteChild = 0x00000040;
@@ -58,6 +85,23 @@ namespace winPEAS.Info.ServicesInfo
         private const int GenericExecute = 0x20000000;
         private const int GenericWrite = 0x40000000;
         private const int GenericRead = unchecked((int)0x80000000);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct ServiceFailureActions
+        {
+            public uint ResetPeriod;
+            public IntPtr RebootMessage;
+            public IntPtr Command;
+            public uint ActionCount;
+            public IntPtr Actions;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct ServiceFailureAction
+        {
+            public int Type;
+            public uint Delay;
+        }
 
         ///////////////////////////////////////////////
         //// Non Standard Services (Non Microsoft) ////
@@ -577,6 +621,373 @@ namespace winPEAS.Info.ServicesInfo
                    normalized.Equals(@"NT AUTHORITY\LocalSystem", StringComparison.OrdinalIgnoreCase);
         }
 
+        //////////////////////////////////////////////////////
+        ////// Writable LocalSystem recovery commands ////////
+        //////////////////////////////////////////////////////
+        public static WritableServiceRecoveryCommandReport GetWritableSystemRecoveryCommands(
+            Dictionary<string, string> currentUserSids)
+        {
+            var report = new WritableServiceRecoveryCommandReport();
+            if (currentUserSids == null || currentUserSids.Count == 0)
+            {
+                return report;
+            }
+
+            string windowsDirectory = Environment.GetEnvironmentVariable("SystemRoot");
+            if (string.IsNullOrWhiteSpace(windowsDirectory))
+            {
+                windowsDirectory = Environment.GetEnvironmentVariable("windir");
+            }
+            if (string.IsNullOrWhiteSpace(windowsDirectory))
+            {
+                return report;
+            }
+
+            var tokenSids = new HashSet<string>(currentUserSids.Keys, StringComparer.OrdinalIgnoreCase);
+            IntPtr serviceManager = IntPtr.Zero;
+            try
+            {
+                serviceManager = Advapi32.OpenSCManager(null, null, ScManagerConnect);
+                if (serviceManager == IntPtr.Zero)
+                {
+                    return report;
+                }
+
+                using (RegistryKey servicesKey = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Services"))
+                {
+                    if (servicesKey == null)
+                    {
+                        return report;
+                    }
+
+                    foreach (string serviceName in servicesKey.GetSubKeyNames())
+                    {
+                        if (report.ServicesInspected >= MaxRecoveryCommandServices)
+                        {
+                            report.ServiceLimitReached = true;
+                            break;
+                        }
+                        if (report.Findings.Count >= MaxRecoveryCommandFindings)
+                        {
+                            report.FindingLimitReached = true;
+                            break;
+                        }
+
+                        report.ServicesInspected++;
+                        try
+                        {
+                            using (RegistryKey serviceKey = servicesKey.OpenSubKey(serviceName))
+                            {
+                                if (serviceKey == null || !IsEligibleRecoveryService(
+                                    GetRegistryInt(serviceKey, "Type"),
+                                    GetRegistryInt(serviceKey, "Start"),
+                                    GetRegistryInt(serviceKey, "LaunchProtected"),
+                                    GetRegistryString(serviceKey, "ObjectName")))
+                                {
+                                    continue;
+                                }
+
+                                string command = GetRegistryString(serviceKey, "FailureCommand");
+                                if (string.IsNullOrWhiteSpace(command) || command.Length > 32767 ||
+                                    !HasRunCommandFailureAction(serviceManager, serviceName))
+                                {
+                                    continue;
+                                }
+
+                                foreach (string target in GetRecoveryCommandTargets(command, windowsDirectory))
+                                {
+                                    if (report.Findings.Count >= MaxRecoveryCommandFindings)
+                                    {
+                                        report.FindingLimitReached = true;
+                                        break;
+                                    }
+
+                                    string accessPath = GetFileSystemAccessPath(
+                                        target,
+                                        windowsDirectory,
+                                        Environment.Is64BitOperatingSystem,
+                                        Environment.Is64BitProcess);
+                                    if (string.IsNullOrWhiteSpace(accessPath) || !IsLocalDrivePath(accessPath))
+                                    {
+                                        continue;
+                                    }
+
+                                    bool targetExists = File.Exists(accessPath);
+                                    string directoryPath = Path.GetDirectoryName(accessPath);
+                                    if (string.IsNullOrWhiteSpace(directoryPath) || !Directory.Exists(directoryPath))
+                                    {
+                                        continue;
+                                    }
+
+                                    RawSecurityDescriptor targetSecurity = targetExists
+                                        ? GetSecurityDescriptor(accessPath, false)
+                                        : null;
+                                    RawSecurityDescriptor directorySecurity = GetSecurityDescriptor(directoryPath, true);
+                                    string accessReason = GetTargetReplacementReason(
+                                        targetSecurity,
+                                        directorySecurity,
+                                        targetExists,
+                                        tokenSids,
+                                        "recovery command target");
+                                    if (string.IsNullOrEmpty(accessReason))
+                                    {
+                                        continue;
+                                    }
+
+                                    report.Findings.Add(new WritableServiceRecoveryCommandInfo
+                                    {
+                                        ServiceName = serviceName,
+                                        Account = GetDisplayAccount(GetRegistryString(serviceKey, "ObjectName")),
+                                        TargetPath = target,
+                                        TargetExists = targetExists,
+                                        AccessReason = accessReason,
+                                    });
+                                }
+                            }
+                        }
+                        catch
+                        {
+                            // A malformed or inaccessible service entry must not stop enumeration.
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Service configuration or registry enumeration may be restricted.
+            }
+            finally
+            {
+                if (serviceManager != IntPtr.Zero)
+                {
+                    Advapi32.CloseServiceHandle(serviceManager);
+                }
+            }
+
+            return report;
+        }
+
+        internal static bool IsEligibleRecoveryService(
+            int? serviceType,
+            int? startType,
+            int? launchProtected,
+            string account)
+        {
+            if (!serviceType.HasValue || !startType.HasValue ||
+                startType.Value == ServiceDisabled ||
+                (launchProtected.HasValue && launchProtected.Value != 0) ||
+                !IsLocalSystemAccount(account))
+            {
+                return false;
+            }
+
+            int win32Type = serviceType.Value & ServiceWin32TypeMask;
+            return win32Type == ServiceWin32OwnProcess || win32Type == ServiceWin32ShareProcess;
+        }
+
+        internal static List<string> GetRecoveryCommandTargets(string rawCommand, string windowsDirectory)
+        {
+            var targets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            string executable;
+            string arguments;
+            if (!TryParseRecoveryCommand(rawCommand, windowsDirectory, out executable, out arguments))
+            {
+                return new List<string>();
+            }
+
+            targets.Add(executable);
+            foreach (string referencedPath in PrivilegedScheduledTasks.ExtractReferencedFilePaths(
+                executable,
+                arguments,
+                windowsDirectory.TrimEnd('\\', '/') + @"\System32"))
+            {
+                if (targets.Count >= 8)
+                {
+                    break;
+                }
+                targets.Add(referencedPath);
+            }
+
+            return new List<string>(targets);
+        }
+
+        internal static bool TryParseRecoveryCommand(
+            string rawCommand,
+            string windowsDirectory,
+            out string executable,
+            out string arguments)
+        {
+            executable = string.Empty;
+            arguments = string.Empty;
+            if (string.IsNullOrWhiteSpace(rawCommand) || string.IsNullOrWhiteSpace(windowsDirectory))
+            {
+                return false;
+            }
+
+            string command = ExpandWindowsPath(rawCommand, windowsDirectory);
+            if (string.IsNullOrWhiteSpace(command) || command.IndexOf('%') >= 0 || command.Length > 32767)
+            {
+                return false;
+            }
+            command = command.Trim();
+
+            int argumentOffset;
+            if (command[0] == '"')
+            {
+                int closingQuote = command.IndexOf('"', 1);
+                if (closingQuote <= 1)
+                {
+                    return false;
+                }
+                executable = command.Substring(1, closingQuote - 1).Trim();
+                argumentOffset = closingQuote + 1;
+            }
+            else
+            {
+                bool startsWithAbsolutePath = command.Length >= 3 &&
+                    char.IsLetter(command[0]) && command[1] == ':' &&
+                    (command[2] == '\\' || command[2] == '/');
+                int whitespace = command.IndexOfAny(new[] { ' ', '\t', '\r', '\n' });
+                int extension = command.IndexOf(".exe", StringComparison.OrdinalIgnoreCase);
+                if (!startsWithAbsolutePath && whitespace >= 0 && extension > whitespace)
+                {
+                    extension = -1;
+                }
+                if (extension >= 0)
+                {
+                    argumentOffset = extension + 4;
+                    executable = command.Substring(0, argumentOffset).Trim();
+                }
+                else
+                {
+                    argumentOffset = whitespace < 0 ? command.Length : whitespace;
+                    executable = command.Substring(0, argumentOffset).Trim();
+                }
+            }
+
+            executable = NormalizeRecoveryExecutable(executable, windowsDirectory);
+            if (string.IsNullOrWhiteSpace(executable) || executable.Length > 32767 ||
+                executable.IndexOf('%') >= 0 || !IsAbsoluteLocalPathSyntax(executable))
+            {
+                executable = string.Empty;
+                return false;
+            }
+
+            arguments = argumentOffset < command.Length
+                ? command.Substring(argumentOffset).Trim()
+                : string.Empty;
+            return true;
+        }
+
+        private static string NormalizeRecoveryExecutable(string executable, string windowsDirectory)
+        {
+            string normalized = StripWin32DevicePrefix(executable.Trim()).Replace('/', '\\');
+            if (normalized.IndexOf('\\') < 0 && normalized.IndexOf(':') < 0)
+            {
+                if (normalized.IndexOf('.') < 0)
+                {
+                    normalized += ".exe";
+                }
+                normalized = windowsDirectory.TrimEnd('\\', '/') + @"\System32\" + normalized;
+            }
+            return StripWin32DevicePrefix(normalized);
+        }
+
+        private static bool IsAbsoluteLocalPathSyntax(string path)
+        {
+            return !string.IsNullOrWhiteSpace(path) && path.Length >= 3 &&
+                   char.IsLetter(path[0]) && path[1] == ':' &&
+                   (path[2] == '\\' || path[2] == '/');
+        }
+
+        private static bool HasRunCommandFailureAction(IntPtr serviceManager, string serviceName)
+        {
+            IntPtr service = IntPtr.Zero;
+            IntPtr buffer = IntPtr.Zero;
+            try
+            {
+                service = Advapi32.OpenService(serviceManager, serviceName, ServiceQueryConfig);
+                if (service == IntPtr.Zero)
+                {
+                    return false;
+                }
+
+                uint bytesNeeded;
+                bool initialResult = Advapi32.QueryServiceConfig2(
+                    service,
+                    ServiceConfigFailureActions,
+                    IntPtr.Zero,
+                    0,
+                    out bytesNeeded);
+                if (initialResult || (uint)Marshal.GetLastWin32Error() != ErrorInsufficientBuffer ||
+                    bytesNeeded < Marshal.SizeOf(typeof(ServiceFailureActions)) ||
+                    bytesNeeded > MaxServiceConfigBuffer)
+                {
+                    return false;
+                }
+
+                uint bufferSize = bytesNeeded;
+                buffer = Marshal.AllocHGlobal((int)bufferSize);
+                if (!Advapi32.QueryServiceConfig2(
+                    service,
+                    ServiceConfigFailureActions,
+                    buffer,
+                    bufferSize,
+                    out bytesNeeded) || bytesNeeded > bufferSize)
+                {
+                    return false;
+                }
+
+                var failureActions = (ServiceFailureActions)Marshal.PtrToStructure(
+                    buffer,
+                    typeof(ServiceFailureActions));
+                if (failureActions.ActionCount == 0 || failureActions.ActionCount > 64 ||
+                    failureActions.Actions == IntPtr.Zero)
+                {
+                    return false;
+                }
+
+                int actionSize = Marshal.SizeOf(typeof(ServiceFailureAction));
+                long bufferStart = buffer.ToInt64();
+                long bufferEnd = bufferStart + bufferSize;
+                long actionsStart = failureActions.Actions.ToInt64();
+                long actionsLength = (long)failureActions.ActionCount * actionSize;
+                if (actionsStart < bufferStart || actionsStart > bufferEnd - actionsLength)
+                {
+                    return false;
+                }
+
+                for (uint index = 0; index < failureActions.ActionCount; index++)
+                {
+                    IntPtr actionPointer = new IntPtr(actionsStart + (long)index * actionSize);
+                    var action = (ServiceFailureAction)Marshal.PtrToStructure(
+                        actionPointer,
+                        typeof(ServiceFailureAction));
+                    if (action.Type == ScActionRunCommand)
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch
+            {
+                // Inaccessible or malformed service configuration is not a finding.
+            }
+            finally
+            {
+                if (buffer != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(buffer);
+                }
+                if (service != IntPtr.Zero)
+                {
+                    Advapi32.CloseServiceHandle(service);
+                }
+            }
+
+            return false;
+        }
+
         internal static bool IsSystemSvchostImage(string rawImagePath, string windowsDirectory)
         {
             if (string.IsNullOrWhiteSpace(rawImagePath) || string.IsNullOrWhiteSpace(windowsDirectory))
@@ -660,6 +1071,21 @@ namespace winPEAS.Info.ServicesInfo
             bool fileExists,
             ISet<string> tokenSids)
         {
+            return GetTargetReplacementReason(
+                fileSecurity,
+                directorySecurity,
+                fileExists,
+                tokenSids,
+                "service DLL");
+        }
+
+        private static string GetTargetReplacementReason(
+            RawSecurityDescriptor fileSecurity,
+            RawSecurityDescriptor directorySecurity,
+            bool fileExists,
+            ISet<string> tokenSids,
+            string targetDescription)
+        {
             if (directorySecurity == null || tokenSids == null || tokenSids.Count == 0)
             {
                 return string.Empty;
@@ -671,24 +1097,24 @@ namespace winPEAS.Info.ServicesInfo
             {
                 if (HasEffectiveAccess(directorySecurity, tokenSids, FileAddFile))
                 {
-                    return "FILE_ADD_FILE on the parent directory can plant the missing service DLL";
+                    return "FILE_ADD_FILE on the parent directory can plant the missing " + targetDescription;
                 }
                 if (canControlDirectory)
                 {
-                    return "WRITE_DAC or WRITE_OWNER on the parent directory can grant DLL creation rights";
+                    return "WRITE_DAC or WRITE_OWNER on the parent directory can grant target creation rights";
                 }
                 return string.Empty;
             }
 
             if (fileSecurity != null && HasEffectiveAccess(fileSecurity, tokenSids, FileWriteData))
             {
-                return "FILE_WRITE_DATA is granted on the configured service DLL";
+                return "FILE_WRITE_DATA is granted on the configured " + targetDescription;
             }
             if (fileSecurity != null &&
                 (HasEffectiveAccess(fileSecurity, tokenSids, WriteDac) ||
                  HasEffectiveAccess(fileSecurity, tokenSids, WriteOwner)))
             {
-                return "WRITE_DAC or WRITE_OWNER on the service DLL can grant overwrite rights";
+                return "WRITE_DAC or WRITE_OWNER on the " + targetDescription + " can grant overwrite rights";
             }
             if (canControlDirectory)
             {
@@ -698,11 +1124,11 @@ namespace winPEAS.Info.ServicesInfo
             bool canCreate = HasEffectiveAccess(directorySecurity, tokenSids, FileAddFile);
             if (canCreate && HasEffectiveAccess(directorySecurity, tokenSids, FileDeleteChild))
             {
-                return "FILE_ADD_FILE and FILE_DELETE_CHILD on the parent directory permit DLL replacement";
+                return "FILE_ADD_FILE and FILE_DELETE_CHILD on the parent directory permit target replacement";
             }
             if (canCreate && fileSecurity != null && HasEffectiveAccess(fileSecurity, tokenSids, Delete))
             {
-                return "DELETE on the DLL plus FILE_ADD_FILE on its parent permit DLL replacement";
+                return "DELETE on the target plus FILE_ADD_FILE on its parent permit replacement";
             }
 
             return string.Empty;

--- a/winPEAS/winPEASexe/winPEAS/Native/Advapi32.cs
+++ b/winPEAS/winPEASexe/winPEAS/Native/Advapi32.cs
@@ -142,6 +142,31 @@ namespace winPEAS.Native
             uint bufSize,
             out uint bufSizeNeeded);
 
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern IntPtr OpenSCManager(
+            string machineName,
+            string databaseName,
+            uint desiredAccess);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern IntPtr OpenService(
+            IntPtr serviceManager,
+            string serviceName,
+            uint desiredAccess);
+
+        [DllImport("advapi32.dll", EntryPoint = "QueryServiceConfig2W", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool QueryServiceConfig2(
+            IntPtr serviceHandle,
+            uint infoLevel,
+            IntPtr buffer,
+            uint bufferSize,
+            out uint bytesNeeded);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool CloseServiceHandle(IntPtr serviceHandle);
+
         [DllImport("advapi32.dll", EntryPoint = "GetNamedSecurityInfoW", CharSet = CharSet.Unicode)]
         internal static extern int GetNamedSecurityInfo(
             string objectName,


### PR DESCRIPTION
<!-- daily-stats-kind: peass -->

<!-- daily-stats-summary: Proposed one high-impact winpeas vulnerability check. -->

Automated proposal for one new, high-impact `winpeas` vulnerability-detection check.

Agent research and validation summary:
PEASS winpeas new-check agent completed successfully with 30 steps. Agent Comment: Plan:
1. Inventory winPEAS checks, architecture, tests, history, remotes, and pending upstream work.
2. Research and rank high-impact passive Windows LPE/credential-exposure candidates using authoritative sources.
3. Implement exactly one cohesive missing check with a focused test where practical.
4. Build/test, inspect the complete diff, and perform static and whitespace validation.

The requested native `update_plan` tool is not available in this runtime, so I’ll maintain the plan explicitly here.
Plan update: starting repository inventory and duplicate-check review; research follows after the check surface and project constraints are mapped.
Plan update: repository layout is confirmed. I’m now cataloging every user-visible winPEAS check and checking remote/upstream changes before selecting a candidate.
Plan update: duplicate review found the recent registry-hive, SCCM NAA, privileged scheduled-task, and service-DLL additions already present or merged, plus one open cleanup PR. I’m now researching several still-missing candidates and will rank them by prevalence, exploitability, and passive evidence quality.
Plan update: research ranking is complete. The strongest missing condition is a writable executable/script configured as a **LocalSystem service recovery command**: Microsoft documents that `SC_ACTION_RUN_COMMAND` launches the configured command under the service account, making a replaceable target a direct SYSTEM execution path when recovery fires. I’m implementing this as a bounded, read-only extension of the existing service checks, with deterministic parsing/eligibility tests.
Plan update: implementation and focused tests are in place. I’m beginning static review now, specifically checking API signatures, pointer bounds, registry view behavior, command parsing, ACL semantics, project inclusion, and the complete diff before building.
Plan update: static review found no whitespace errors; the check is bounded to 4,096 services/64 findings, queries only `SERVICE_QUERY_CONFIG`, validates the 8 KiB native buffer and action-array bounds, avoids UNC/device paths, closes all SCM handles, and does not print raw recovery command arguments. I’m moving to build/test validation and will fix any compiler or test failures.
Plan update: the first validation pass exposed one parser edge case—bare interpreter names followed by an `.exe` argument could be mistaken for an absolute executable. I’m correcting that before the final static/test pass; no runtime behavior was exercised.
Plan update: the repository’s supported validation is Windows/MSBuild, but this container has no `dotnet`, `msbuild`, `xbuild`, Mono, CMake, or C# compiler. I’ll therefore run an independent C# syntax parser, XML/project integrity checks, focused logic-model tests, and final diff/whitespace audits; I will explicitly avoid claiming a Windows build ran.
Plan update: syntax and project-file validation pass. Before finalizing, I’m doing one last complete-diff/static safety review, then I’ll record the selected vulnerability condition with the required Chack vulnerability-saving tool and summarize the validation limitations precisely.
Plan update: final safety review passes with only the intended five files changed and no active/write/network behavior added. I’m checking the reused scheduled-task path extractor’s platform-independent behavior once more, then I’ll finalize.
Plan update: the last parser review improved fidelity to `CreateProcess` by normalizing extensionless bare executable names to `.exe`. I’m rerunning the full syntax, XML, whitespace, scope, and passive-behavior checks on the final state.
## Selected check

**Writable LocalSystem service recovery-command targets** (`SC_ACTION_RUN_COMMAND`, MITRE T1543.003).

Microsoft documents that recovery commands run under the service’s configured account. Therefore, a writable executable or referenced script belonging to a LocalSystem service provides a direct SYSTEM execution opportunity when recovery fires. This is an OS-native mechanism applicable across third-party Windows services, not a version-table duplicate. [Microsoft `SERVICE_FAILURE_ACTIONS`](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_failure_actionsw), [MITRE T1543.003](https://attack.mitre.org/techniques/T1543/003/)

## Detection

The new passive check:

- Enumerates enabled, unprotected Win32 services running as LocalSystem.
- Uses read-only `QueryServiceConfig2W` with `SERVICE_QUERY_CONFIG` to confirm an actual `SC_ACTION_RUN_COMMAND`.
- Parses direct executables and referenced interpreter scripts.
- Expands Windows paths while rejecting unresolved variables, UNC/device paths, and network drives.
- Evaluates effective file and parent-directory ACLs for overwrite, replacement, or missing-file planting rights.
- Handles x86/Sysnative path behavior.
- Caps enumeration at 4,096 services and 64 findings.
- Never starts, stops, crashes, or modifies a service, and does not print raw command arguments.

The API and required query permissions follow Microsoft’s documentation. [QueryServiceConfig2W](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-queryserviceconfig2w), [Service security and access rights](https://learn.microsoft.com/en-us/windows/win32/services/service-security-and-access-rights)

## Files changed

- `winPEAS/…/Checks/ServicesInfo.cs`
- `winPEAS/…/Info/ServicesInfo/ServicesInfoHelper.cs`
- `winPEAS/…/Native/Advapi32.cs`
- `winPEAS/…/Tests/WritableServiceRecoveryCommandTests.cs`
- `winPEAS/…/Tests/winPEAS.Tests.csproj`

## Validation

- Reviewed winPEAS history, remote branches, merged new-check work, and open PRs; no duplicate recovery-command check found.
- `git diff --check`: passed.
- Independent C# syntax parsing of all changed C# files: passed.
- Test-project XML and compile-item validation: passed.
- Static passive-behavior and resource-disposal review: passed.
- Added four focused regression tests for eligibility, parsing, interpreter/script extraction, and unsafe-path rejection.

MSBuild/MSTest could not run because this Linux environment contains no compatible .NET, Mono, MSBuild, or C# toolchain. The authoritative Windows CI build remains pending.

Generated by the PEASS New Vulnerability Checks workflow. This PR must pass PEASS PR-tests and normal Chack-Agent review.
