### PR TITLE
fix(links): repoint remaining hacktricks URLs that 404 after book reorg

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ These tools search for possible **local privilege escalation paths** that you co
 - Check the **Local Windows Privilege Escalation checklist** from **[book.hacktricks.wiki](https://book.hacktricks.wiki/en/windows-hardening/checklist-windows-privilege-escalation.html)**
 - **[WinPEAS](https://github.com/peass-ng/PEASS-ng/tree/master/winPEAS) - Windows local Privilege Escalation Awesome Script (C#.exe and .bat)**
 
-- Check the **Local Linux Privilege Escalation checklist** from **[book.hacktricks.wiki](https://book.hacktricks.wiki/en/linux-hardening/linux-privilege-escalation-checklist.html)**
+- Check the **Local Linux Privilege Escalation checklist** from **[book.hacktricks.wiki](https://book.hacktricks.wiki/en/linux-hardening/main-system-information/linux-privilege-escalation-checklist.html)**
 - **[LinPEAS](https://github.com/peass-ng/PEASS-ng/tree/master/linPEAS) - Linux local Privilege Escalation Awesome Script (.sh)**
 
 ## Quick Start

--- a/linPEAS/README.md
+++ b/linPEAS/README.md
@@ -4,7 +4,7 @@
 
 **LinPEAS is a script that search for possible paths to escalate privileges on Linux/Unix\*/MacOS hosts. The checks are explained on [book.hacktricks.wiki](https://book.hacktricks.wiki/en/linux-hardening/linux-basics/linux-privilege-escalation/index.html)**
 
-Check the **Local Linux Privilege Escalation checklist** from **[book.hacktricks.wiki](https://book.hacktricks.wiki/en/linux-hardening/linux-privilege-escalation-checklist.html)**.
+Check the **Local Linux Privilege Escalation checklist** from **[book.hacktricks.wiki](https://book.hacktricks.wiki/en/linux-hardening/main-system-information/linux-privilege-escalation-checklist.html)**.
 
 [![asciicast](https://asciinema.org/a/250532.png)](https://asciinema.org/a/309566)
 

--- a/linPEAS/builder/linpeas_parts/1_system_information/3_USBCreator.sh
+++ b/linPEAS/builder/linpeas_parts/1_system_information/3_USBCreator.sh
@@ -30,7 +30,7 @@
 
 if (busctl list 2>/dev/null | grep -q com.ubuntu.USBCreator) || [ "$DEBUG" ]; then
     print_2title "USBCreator" "T1548.003,T1068"
-    print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/d-bus-enumeration-and-command-injection-privilege-escalation.html"
+    print_info "https://book.hacktricks.wiki/en/linux-hardening/processes-crontab-systemd-dbus/d-bus-enumeration-and-command-injection-privilege-escalation.html"
 
     pc_version=$(dpkg -l 2>/dev/null | grep policykit-desktop-privileges | grep -oP "[0-9][0-9a-zA-Z\.]+")
     if [ -z "$pc_version" ]; then

--- a/linPEAS/builder/linpeas_parts/2_container/5_Container_breakout.sh
+++ b/linPEAS/builder/linpeas_parts/2_container/5_Container_breakout.sh
@@ -16,7 +16,7 @@
 if [ "$inContainer" ]; then
     echo ""
     print_2title "Container & breakout enumeration" "T1611"
-    print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/container-security/index.html"
+    print_info "https://book.hacktricks.wiki/en/linux-hardening/containers-namespaces/container-security/index.html"
     
     # Basic container info
     print_list "Container ID ...................$NC $(cat /etc/hostname && echo -n '\n')"
@@ -148,7 +148,7 @@ if [ "$inContainer" ]; then
     
     # Mount, procfs and sysfs escape surfaces
     print_3title "Mount, procfs & sysfs surfaces" "T1611"
-    print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/container-security/sensitive-host-mounts.html"
+    print_info "https://book.hacktricks.wiki/en/linux-hardening/containers-namespaces/container-security/sensitive-host-mounts.html"
     
     checkProcSysBreakouts
     root_mount_mode="$(awk '$5=="/"{print $6; exit}' /proc/self/mountinfo 2>/dev/null | cut -d',' -f1)"
@@ -183,7 +183,7 @@ if [ "$inContainer" ]; then
     
     # Capability checks
     print_3title "Capability Checks" "T1611"
-    print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/container-security/protections/capabilities.html"
+    print_info "https://book.hacktricks.wiki/en/linux-hardening/containers-namespaces/container-security/protections/capabilities.html"
     
     print_list "Dangerous capabilities ......... "$NC
     if [ "$(command -v capsh || echo -n '')" ]; then 
@@ -208,7 +208,7 @@ if [ "$inContainer" ]; then
     # Namespace checks. From inside a container we often cannot prove host namespace sharing directly,
     # so prefer raw namespace handles and practical indicators over misleading "host namespace = yes/no" guesses.
     print_3title "Namespaces & sharing indicators" "T1611"
-    print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/container-security/protections/namespaces/index.html"
+    print_info "https://book.hacktricks.wiki/en/linux-hardening/containers-namespaces/container-security/protections/namespaces/index.html"
     
     print_list "Current namespaces ............. "$NC
     ls -l /proc/self/ns/

--- a/linPEAS/builder/linpeas_parts/2_container/7_RW_bind_mounts_nosuid.sh
+++ b/linPEAS/builder/linpeas_parts/2_container/7_RW_bind_mounts_nosuid.sh
@@ -21,7 +21,7 @@ containerCheck
 if [ "$inContainer" ]; then
   echo ""
   print_2title "Container - Writable bind mounts w/o nosuid (SUID persistence risk)" "T1611"
-  print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/container-security/privileged-containers.html#writable-bind-mounts"
+  print_info "https://book.hacktricks.wiki/en/linux-hardening/containers-namespaces/container-security/privileged-containers.html#writable-bind-mounts"
 
   if [ -r /proc/self/mountinfo ]; then
     CT_RW_bind_mounts_matches=$(grep -E "(^| )bind( |$)" /proc/self/mountinfo 2>/dev/null | grep -E "(^|,)rw(,|$)" | grep -v "nosuid" || true)

--- a/linPEAS/builder/linpeas_parts/6_users_information/10_Pkexec.sh
+++ b/linPEAS/builder/linpeas_parts/6_users_information/10_Pkexec.sh
@@ -15,7 +15,7 @@
 
 
 print_2title "Checking Pkexec and Polkit" "T1548.003,T1548.004,T1068"
-print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/interesting-groups-linux-pe/index.html#pe---method-2"
+print_info "https://book.hacktricks.wiki/en/linux-hardening/user-information/interesting-groups-linux-pe/index.html#pe---method-2"
 
 echo ""
 print_3title "Polkit Binary" "T1548.003,T1068"

--- a/linPEAS/builder/linpeas_parts/6_users_information/11_Superusers.sh
+++ b/linPEAS/builder/linpeas_parts/6_users_information/11_Superusers.sh
@@ -15,7 +15,7 @@
 
 
 print_2title "Superusers and UID 0 Users" "T1087.001"
-print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/interesting-groups-linux-pe/index.html"
+print_info "https://book.hacktricks.wiki/en/linux-hardening/user-information/interesting-groups-linux-pe/index.html"
 
 # Check /etc/passwd for UID 0 users
 echo ""

--- a/linPEAS/builder/linpeas_parts/7_software_information/Containerd.sh
+++ b/linPEAS/builder/linpeas_parts/7_software_information/Containerd.sh
@@ -21,7 +21,7 @@ if ! [ "$SEARCH_IN_FOLDER" ]; then
   crictl_cli=$(command -v crictl || echo -n '')
   if [ "$containerd" ] || [ "$containerd_cli" ] || [ "$nerdctl_cli" ] || [ "$crictl_cli" ] || [ "$DEBUG" ]; then
     print_2title "Checking if containerd/CRI tooling is available" "T1613"
-    print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/container-security/runtime-api-and-daemon-exposure.html"
+    print_info "https://book.hacktricks.wiki/en/linux-hardening/containers-namespaces/container-security/runtime-api-and-daemon-exposure.html"
     if [ "$containerd" ]; then
       echo "containerd was found in $containerd" | sed -${E} "s,.*,${SED_RED},"
     fi

--- a/linPEAS/builder/linpeas_parts/7_software_information/Docker.sh
+++ b/linPEAS/builder/linpeas_parts/7_software_information/Docker.sh
@@ -16,7 +16,7 @@
 
 if [ "$PSTORAGE_DOCKER" ] || [ "$DEBUG" ]; then
   print_2title "Searching docker files (limit 70)" "T1613"
-  print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/container-security/index.html"
+  print_info "https://book.hacktricks.wiki/en/linux-hardening/containers-namespaces/container-security/index.html"
   printf "%s\n" "$PSTORAGE_DOCKER" | head -n 70 | while read f; do
     ls -l "$f" 2>/dev/null
     if ! [ "$IAMROOT" ] && [ -S "$f" ] && [ -w "$f" ]; then

--- a/linPEAS/builder/linpeas_parts/7_software_information/Kerberos.sh
+++ b/linPEAS/builder/linpeas_parts/7_software_information/Kerberos.sh
@@ -19,7 +19,7 @@ klist_exists="$(command -v klist || echo -n '')"
 kinit_exists="$(command -v kinit || echo -n '')"
 if [ "$kadmin_exists" ] || [ "$klist_exists" ] || [ "$kinit_exists" ] || [ "$PSTORAGE_KERBEROS" ] || [ "$DEBUG" ]; then
   print_2title "Searching kerberos conf files and tickets" "T1558.003"
-  print_info "https://book.hacktricks.wiki/en/linux-hardening/privilege-escalation/linux-active-directory.html#linux-active-directory"
+  print_info "https://book.hacktricks.wiki/en/linux-hardening/user-information/linux-active-directory.html#linux-active-directory"
 
   if [ "$kadmin_exists" ]; then echo "kadmin was found on $kadmin_exists" | sed "s,$kadmin_exists,${SED_RED},"; fi
   if [ "$kinit_exists" ]; then echo "kadmin was found on $kinit_exists" | sed "s,$kinit_exists,${SED_RED},"; fi

--- a/linPEAS/builder/linpeas_parts/linpeas_base/0_variables_base.sh
+++ b/linPEAS/builder/linpeas_parts/linpeas_base/0_variables_base.sh
@@ -409,7 +409,7 @@ printf ${BLUE}"          $SCRIPTNAME-$VERSION ${YELLOW}by carlospolop\n"$NC;
 echo ""
 printf ${YELLOW}"ADVISORY: ${BLUE}$ADVISORY\n$NC"
 echo ""
-printf ${BLUE}"Linux Privesc Checklist: ${YELLOW}https://book.hacktricks.wiki/en/linux-hardening/linux-privilege-escalation-checklist.html\n"$NC
+printf ${BLUE}"Linux Privesc Checklist: ${YELLOW}https://book.hacktricks.wiki/en/linux-hardening/main-system-information/linux-privilege-escalation-checklist.html\n"$NC
 printf ${BLUE}"Best Linux PE & Hardening course: ${YELLOW}https://hacktricks-training.com/courses/lhe/\n"$NC
 echo " LEGEND:" | sed "s,LEGEND,${C}[1;4m&${C}[0m,"
 echo "  RED/YELLOW: 95% a PE vector" | sed "s,RED/YELLOW,${SED_RED_YELLOW},"

--- a/winPEAS/winPEASexe/winPEAS/Checks/ActiveDirectoryInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/ActiveDirectoryInfo.cs
@@ -673,7 +673,7 @@ namespace winPEAS.Checks
             {
                 Beaprint.MainPrint("gMSA readable managed passwords", "T1003");
                 Beaprint.LinkPrint(
-                    "https://book.hacktricks.wiki/en/windows-hardening/active-directory-methodology/gmsa.html",
+                    "https://book.hacktricks.wiki/en/windows-hardening/active-directory-methodology/golden-dmsa-gmsa.html",
                     "Look for Group Managed Service Accounts you can read (msDS-ManagedPassword)");
 
                 if (!Checks.IsPartOfDomain)

--- a/winPEAS/winPEASexe/winPEAS/Checks/SystemInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/SystemInfo.cs
@@ -1425,7 +1425,7 @@ namespace winPEAS.Checks
                         {
                             if (!anyFinding)
                             {
-                                Beaprint.LinkPrint("https://book.hacktricks.wiki/en/windows-hardening/active-directory-methodology/gpo-abuse.html", "Why it matters");
+                                Beaprint.LinkPrint("https://book.hacktricks.wiki/en/windows-hardening/active-directory-methodology/index.html", "Why it matters");
                             }
                             anyFinding = true;
                             Beaprint.BadPrint($"    [!] Writable applied GPO detected");

--- a/winPEAS/winPEASexe/winPEAS/Checks/UserInfo.cs
+++ b/winPEAS/winPEASexe/winPEAS/Checks/UserInfo.cs
@@ -158,7 +158,7 @@ namespace winPEAS.Checks
             try
             {
                 Beaprint.MainPrint("RDP Sessions", "T1563.002");
-                Beaprint.LinkPrint("https://book.hacktricks.wiki/en/windows-hardening/windows-local-privilege-escalation/credentials-mgmt/rdp-sessions", "Disconnected high-privilege RDP sessions keep reusable tokens inside LSASS.");
+                Beaprint.LinkPrint("https://book.hacktricks.wiki/en/windows-hardening/active-directory-methodology/rdp-sessions-abuse.html", "Disconnected high-privilege RDP sessions keep reusable tokens inside LSASS.");
                 List<Dictionary<string, string>> rdp_sessions = UserInfoHelper.GetRDPSessions();
                 if (rdp_sessions.Count > 0)
                 {
@@ -202,7 +202,7 @@ namespace winPEAS.Checks
                             string source = string.IsNullOrEmpty(flaggedIp) ? "local" : flaggedIp;
                             Beaprint.BadPrint(string.Format("        -> Session {0} ({1}) from {2}", flaggedSessionId, userDisplay, source));
                         }
-                        Beaprint.LinkPrint("https://book.hacktricks.wiki/en/windows-hardening/windows-local-privilege-escalation/credentials-mgmt/rdp-sessions", "Dump LSASS / steal tokens (e.g., comsvcs.dll, LsaLogonSessions, custom SSPs) to reuse those privileges.");
+                        Beaprint.LinkPrint("https://book.hacktricks.wiki/en/windows-hardening/active-directory-methodology/rdp-sessions-abuse.html", "Dump LSASS / steal tokens (e.g., comsvcs.dll, LsaLogonSessions, custom SSPs) to reuse those privileges.");
                     }
                 }
                 else


### PR DESCRIPTION
Follow-up to #698. That PR fixed the `linux-privilege-escalation` **index.html** links, but a full sweep of every hacktricks URL in the repo (checked against the live site and `sitemap.xml`) showed several other pages that moved in the book reorganization and still returned **"Page not found"**.

## Broken pages repointed
| Old (404) | New |
|---|---|
| `linux-hardening/linux-privilege-escalation-checklist.html` | `linux-hardening/main-system-information/linux-privilege-escalation-checklist.html` |
| `linux-hardening/privilege-escalation/container-security/*` | `linux-hardening/containers-namespaces/container-security/*` |
| `linux-hardening/privilege-escalation/d-bus-enumeration-...` | `linux-hardening/processes-crontab-systemd-dbus/d-bus-enumeration-...` |
| `linux-hardening/privilege-escalation/interesting-groups-linux-pe/*` | `linux-hardening/user-information/interesting-groups-linux-pe/*` |
| `linux-hardening/privilege-escalation/linux-active-directory.html` | `linux-hardening/user-information/linux-active-directory.html` |
| `windows-hardening/active-directory-methodology/gmsa.html` | `.../golden-dmsa-gmsa.html` |
| `windows-hardening/active-directory-methodology/gpo-abuse.html` | `windows-hardening/active-directory-methodology/index.html` (GPO abuse now documented there) |
| `windows-hardening/windows-local-privilege-escalation/credentials-mgmt/rdp-sessions` | `windows-hardening/active-directory-methodology/rdp-sessions-abuse.html` |

## Files touched
9 linPEAS builder parts (container/pkexec/superusers/containerd/docker/kerberos/usbcreator/variables), 3 winPEAS `.cs` checks, and the top-level + linPEAS READMEs — 18 replacements across 14 files.

## Verification
- Every hacktricks base URL in the repo was fetched and its page title checked; after this change **none** return "Page not found".
- The only remaining `book.hacktricks.xyz` strings are synthetic fixtures in the parser escaping tests (`test_json2html.py` / `test_json2pdf.py`) and are intentionally left unchanged.
- `bash -n` passes on all modified shell files.
- `linpeas.sh` is CI-built (not committed), so only builder parts needed editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)