### PR TITLE
Fix CI-master_test failure (run #34243790613)

### DIFF
--- a/.github/workflows/CI-master_tests.yml
+++ b/.github/workflows/CI-master_tests.yml
@@ -156,10 +156,20 @@ jobs:
           path: winPEAS\winPEASexe\binaries\x86\Release\winPEASx86.exe
       
       - name: Upload winpeasany
+        id: upload_winpeasany
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: winPEASany.exe
           path: winPEAS\winPEASexe\binaries\Release\winPEASany.exe
+
+      - name: Retry upload winpeasany
+        if: ${{ steps.upload_winpeasany.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: winPEASany.exe
+          path: winPEAS\winPEASexe\binaries\Release\winPEASany.exe
+          overwrite: true
       
       - name: Upload winpeasx64ofs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Automated Chack Agent fix for failing CI-master_test run: https://github.com/peass-ng/PEASS-ng/actions/runs/34243790613